### PR TITLE
Add support for inline option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,17 @@ For example, if an app or a command declares 4 options a, b, c and d, `[OPTIONS]
 x.Spec = "[-a | -b | -c | -d]..."
 ```
 
+### Inline option values
+
+You can use the `=<some-text>` notation right after an option (long or short form) to give an inline description or value.
+
+An example:
+
+```go
+x.Spec = "[ -a=<absolute-path> | --timeout=<in seconds> ] ARG"
+```
+
+The inline values are ignored by the spec parser and are just there for the final user as a contextual hint.
 
 ### Operators
 

--- a/doc.go
+++ b/doc.go
@@ -284,6 +284,12 @@ This is equivalent to a repeatable choice between all the available options.
 For example, if an app or a command declares 4 options a, b, c and d, [OPTIONS] is equivalent to
 	x.Spec = "[-a | -b | -c | -d]..."
 
+Inline option values
+
+You can use the =<some-text> notation right after an option (long or short form) to give an inline description or value.
+An example:
+	x.Spec = "[ -a=<absolute-path> | --timeout=<in seconds> ] ARG"
+The inline values are ignored by the spec parser and are just there for the final user as a contextual hint.
 
 Operators
 

--- a/spec_n_parse_test.go
+++ b/spec_n_parse_test.go
@@ -1127,3 +1127,33 @@ func TestSpecOptOrdering(t *testing.T) {
 	}
 
 }
+
+func TestSpecOptInlineValue(t *testing.T) {
+	var f, g, x *string
+	var y *[]string
+	init := func(c *Cmd) {
+		f = c.StringOpt("f", "", "")
+		g = c.StringOpt("giraffe", "", "")
+		x = c.StringOpt("x", "", "")
+		y = c.StringsOpt("y", nil, "")
+	}
+	spec := "-x=<wolf-name> [ -f=<fish-name> | --giraffe=<giraffe-name> ] -y=<dog>..."
+
+	okCmd(t, spec, init, []string{"-x=a", "-y=b"})
+	require.Equal(t, "a", *x)
+	require.Equal(t, []string{"b"}, *y)
+
+	okCmd(t, spec, init, []string{"-x=a", "-y=b", "-y=c"})
+	require.Equal(t, "a", *x)
+	require.Equal(t, []string{"b", "c"}, *y)
+
+	okCmd(t, spec, init, []string{"-x=a", "-f=f", "-y=b"})
+	require.Equal(t, "a", *x)
+	require.Equal(t, "f", *f)
+	require.Equal(t, []string{"b"}, *y)
+
+	okCmd(t, spec, init, []string{"-x=a", "--giraffe=g", "-y=b"})
+	require.Equal(t, "a", *x)
+	require.Equal(t, "g", *g)
+	require.Equal(t, []string{"b"}, *y)
+}

--- a/spec_parser.go
+++ b/spec_parser.go
@@ -177,7 +177,7 @@ func (p *uParser) atom() (*state, *state) {
 			panic(fmt.Sprintf("Undeclared option %s", name))
 		}
 		end = start.t(opt, newState(p.cmd))
-
+		p.found(utOptValue)
 	case p.found(utLongOpt):
 		if p.rejectOptions {
 			p.back()
@@ -190,6 +190,7 @@ func (p *uParser) atom() (*state, *state) {
 			panic(fmt.Sprintf("Undeclared option %s", name))
 		}
 		end = start.t(opt, newState(p.cmd))
+		p.found(utOptValue)
 	case p.found(utOptSeq):
 		if p.rejectOptions {
 			p.back()

--- a/spec_tk_test.go
+++ b/spec_tk_test.go
@@ -45,6 +45,11 @@ func TestUTokenize(t *testing.T) {
 
 		{"-aBc", []*uToken{{utOptSeq, "aBc", 1}}},
 		{"--", []*uToken{{utDoubleDash, "--", 0}}},
+		{"=<bla>", []*uToken{{utOptValue, "=<bla>", 0}}},
+		{"=<bla-bla>", []*uToken{{utOptValue, "=<bla-bla>", 0}}},
+		{"=<bla--bla>", []*uToken{{utOptValue, "=<bla--bla>", 0}}},
+		{"-p=<file-path>", []*uToken{{utShortOpt, "-p", 0}, {utOptValue, "=<file-path>", 2}}},
+		{"--path=<absolute-path>", []*uToken{{utLongOpt, "--path", 0}, {utOptValue, "=<absolute-path>", 6}}},
 	}
 	for _, c := range cases {
 		t.Logf("test %s", c.usage)
@@ -83,6 +88,11 @@ func TestUTokenizeErrors(t *testing.T) {
 		{"-", 1},
 		{"---x", 2},
 		{"-x-", 2},
+
+		{"=", 1},
+		{"=<", 2},
+		{"=<dsdf", 6},
+		{"=<>", 2},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Lets you explain an option value in the spec:

```go
x.Spec = "[ -a=<absolute-path> | --timeout=<in seconds> ] ARG"
```

Fixes #14