### PR TITLE
Support for app Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ cp.Action = func() {
     fmt.Printf("Hello world\n")
 }
 ```
+
+If you want you can add support for printing the app version (invoked by ```-v, --version```) like so:
+```go
+cp.Version("v version", "cp 1.2.3")
+```
+
 Finally, in your main func, call Run on the app:
 
 ```go
@@ -152,7 +158,6 @@ EnvVar accepts a space separated list of environment variables names to be used 
 
 The result is a pointer to a value that will be populated after parsing the command line arguments.
 You can access the values in the Action func.
-
 
 ## Operators
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -54,7 +54,7 @@ func forkTest(testName string, fork func(), test func(err error)) {
 	if os.Getenv("MOW_DO_IT") == "1" {
 		fork()
 	} else {
-		cmd := exec.Command(os.Args[0], "-test.run="+testName)
+		cmd := exec.Command(os.Args[0], "-test.run=" + testName)
 		cmd.Stderr = ioutil.Discard
 		cmd.Stdout = ioutil.Discard
 
@@ -78,6 +78,21 @@ func TestHelpShortcut(t *testing.T) {
 				return
 			}
 			t.Fatalf("process ran with err %v, want exit status != 0", err)
+		})
+}
+
+func TestVersionShortcut(t *testing.T) {
+	forkTest("TestVersionShortcut",
+		func() {
+			app := App("cp", "")
+			app.Version("v version", "cp 1.2.3")
+			app.Run([]string{"cp", "--version"})
+		},
+		func(err error) {
+			if err == nil {
+				return
+			}
+			t.Fatalf("process ran with err %v, want exit status == 0", err)
 		})
 }
 

--- a/commands.go
+++ b/commands.go
@@ -398,18 +398,24 @@ func (c *Cmd) parse(args []string, entry, inFlow, outFlow *step) error {
 
 }
 
-func (c *Cmd) helpRequested(args []string) bool {
+func (c *Cmd) isArgSet(args []string, searchArgs []string) bool {
 	for _, arg := range args {
 		for _, sub := range c.commands {
 			if arg == sub.name {
 				return false
 			}
 		}
-		if arg == "-h" || arg == "--help" {
-			return true
+		for _, searchArg := range searchArgs {
+			if arg == searchArg {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func (c *Cmd) helpRequested(args []string) bool {
+	return c.isArgSet(args, []string{"-h", "--help"})
 }
 
 func (c *Cmd) getOptsAndArgs(args []string) int {

--- a/options.go
+++ b/options.go
@@ -21,13 +21,13 @@ type BoolOpt struct {
 
 	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
 	// The one letter names will then be called with a single dash (short option), the others with two (long options).
-	Name string
+	Name      string
 	// The option description as will be shown in help messages
-	Desc string
+	Desc      string
 	// A space separated list of environment variables names to be used to initialize this option
-	EnvVar string
+	EnvVar    string
 	// The option's inital value
-	Value bool
+	Value     bool
 	// A boolean to display or not the current value of the option in the help message
 	HideValue bool
 }
@@ -38,13 +38,13 @@ type StringOpt struct {
 
 	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
 	// The one letter names will then be called with a single dash (short option), the others with two (long options).
-	Name string
+	Name      string
 	// The option description as will be shown in help messages
-	Desc string
+	Desc      string
 	// A space separated list of environment variables names to be used to initialize this option
-	EnvVar string
+	EnvVar    string
 	// The option's inital value
-	Value string
+	Value     string
 	// A boolean to display or not the current value of the option in the help message
 	HideValue bool
 }
@@ -55,13 +55,13 @@ type IntOpt struct {
 
 	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
 	// The one letter names will then be called with a single dash (short option), the others with two (long options).
-	Name string
+	Name      string
 	// The option description as will be shown in help messages
-	Desc string
+	Desc      string
 	// A space separated list of environment variables names to be used to initialize this option
-	EnvVar string
+	EnvVar    string
 	// The option's inital value
-	Value int
+	Value     int
 	// A boolean to display or not the current value of the option in the help message
 	HideValue bool
 }
@@ -72,14 +72,14 @@ type StringsOpt struct {
 
 	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
 	// The one letter names will then be called with a single dash (short option), the others with two (long options).
-	Name string
+	Name      string
 	// The option description as will be shown in help messages
-	Desc string
+	Desc      string
 	// A space separated list of environment variables names to be used to initialize this option.
 	// The env variable should contain a comma separated list of values
-	EnvVar string
+	EnvVar    string
 	// The option's inital value
-	Value []string
+	Value     []string
 	// A boolean to display or not the current value of the option in the help message
 	HideValue bool
 }
@@ -90,14 +90,14 @@ type IntsOpt struct {
 
 	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
 	// The one letter names will then be called with a single dash (short option), the others with two (long options).
-	Name string
+	Name      string
 	// The option description as will be shown in help messages
-	Desc string
+	Desc      string
 	// A space separated list of environment variables names to be used to initialize this option.
 	// The env variable should contain a comma separated list of values
-	EnvVar string
+	EnvVar    string
 	// The option's inital value
-	Value []int
+	Value     []int
 	// A boolean to display or not the current value of the option in the help message
 	HideValue bool
 }
@@ -182,13 +182,8 @@ func (o *opt) set(s string) error {
 	return vset(o.value, s)
 }
 
-func (c *Cmd) mkOpt(opt opt, defaultValue interface{}) interface{} {
-	value := reflect.ValueOf(defaultValue)
-	res := reflect.New(value.Type())
-
-	vinit(res, opt.envVar, defaultValue)
-
-	namesSl := strings.Split(opt.name, " ")
+func mkOptStrs(optName string) []string {
+	namesSl := strings.Split(optName, " ")
 	for i, name := range namesSl {
 		prefix := "-"
 		if len(name) > 1 {
@@ -196,12 +191,20 @@ func (c *Cmd) mkOpt(opt opt, defaultValue interface{}) interface{} {
 		}
 		namesSl[i] = prefix + name
 	}
+	return namesSl
+}
 
-	opt.names = namesSl
+func (c *Cmd) mkOpt(opt opt, defaultValue interface{}) interface{} {
+	value := reflect.ValueOf(defaultValue)
+	res := reflect.New(value.Type())
+
+	vinit(res, opt.envVar, defaultValue)
+
+	opt.names = mkOptStrs(opt.name)
 	opt.value = res
 
 	c.options = append(c.options, &opt)
-	for _, name := range namesSl {
+	for _, name := range opt.names {
 		c.optionsIdx[name] = &opt
 	}
 


### PR DESCRIPTION
I like how ```Cli``` is really just another ```Cmd```, it keeps things simple :-)
This did pose a little bit of dilemma as where to add the extra versioning info needed for this new functionality. I gave some thought to adding the version to the ```Cmd``` struct but ended up adding it to ```Cli``` as I found that versioning was Cli specific and didn't have meaning at the ```Cmd``` level, except for the one ```Cmd``` that happens to be the ```Cli```.

In order to implement that somewhat elegantly, I ended up decorating ```Cmd.parse``` for the ```Cli``` struct, adding the code to handle the version and then just calling  ```Cmd.parse```.

Related to testing, I'm not sure I'm entirely following how ```forkTest``` actually tests anything given that it discards stdOut and stdErr. I ended up duplicating what already existed, but I'm not sure whether that is actually useful. I'm fairly new to Go programming, so let me know if it's just me missing something. 
