### PR TITLE
Rework args and options values printing in help messages

### DIFF
--- a/args.go
+++ b/args.go
@@ -5,15 +5,6 @@ import (
 	"reflect"
 )
 
-type arg struct {
-	name      string
-	desc      string
-	envVar    string
-	hideValue bool
-
-	value reflect.Value
-}
-
 // BoolArg describes a boolean argument
 type BoolArg struct {
 	BoolParam
@@ -141,6 +132,15 @@ func (c *Cmd) IntsArg(name string, value []int, desc string) *[]int {
 	return c.mkArg(arg{name: name, desc: desc}, value).(*[]int)
 }
 
+type arg struct {
+	name          string
+	desc          string
+	envVar        string
+	helpFormatter func(interface{}) string
+	value         reflect.Value
+	hideValue     bool
+}
+
 func (a *arg) String() string {
 	return fmt.Sprintf("ARG(%s)", a.name)
 }
@@ -156,6 +156,8 @@ func (a *arg) set(s string) error {
 func (c *Cmd) mkArg(arg arg, defaultvalue interface{}) interface{} {
 	value := reflect.ValueOf(defaultvalue)
 	res := reflect.New(value.Type())
+
+	arg.helpFormatter = formatterFor(value.Type())
 
 	vinit(res, arg.envVar, defaultvalue)
 

--- a/commands.go
+++ b/commands.go
@@ -291,23 +291,17 @@ func (c *Cmd) PrintHelp() {
 }
 
 func (c *Cmd) formatArgValue(arg *arg) string {
-	var value string
 	if arg.hideValue {
-		value = " "
-	} else {
-		value = fmt.Sprintf("=%#v", arg.get())
+		return " "
 	}
-	return value
+	return "=" + arg.helpFormatter(arg.get())
 }
 
 func (c *Cmd) formatOptValue(opt *opt) string {
-	var value string
 	if opt.hideValue {
-		value = " "
-	} else {
-		value = fmt.Sprintf("=%#v", opt.get())
+		return " "
 	}
-	return value
+	return "=" + opt.helpFormatter(opt.get())
 }
 
 func (c *Cmd) formatDescription(desc, envVar string) string {

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatters(t *testing.T) {
+	cases := []struct {
+		input    interface{}
+		expected string
+	}{
+		{true, "true"},
+		{false, "false"},
+
+		{"", `""`},
+		{"val", `"val"`},
+
+		{42, "42"},
+
+		{[]string{}, `[]`},
+		{[]string{"a"}, `["a"]`},
+		{[]string{"a", "b"}, `["a", "b"]`},
+
+		{[]int{}, "[]"},
+		{[]int{1}, "[1]"},
+		{[]int{1, 2}, "[1, 2]"},
+	}
+
+	for _, cas := range cases {
+		f := formatterFor(reflect.TypeOf(cas.input))
+		require.Equal(t, cas.expected, f(cas.input), "formatting error for value %v (%T)", cas.input, cas.input)
+	}
+}

--- a/formatters.go
+++ b/formatters.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func formatterFor(t reflect.Type) func(interface{}) string {
+	switch t.Kind() {
+	case reflect.Bool:
+		return boolFormatter
+	case reflect.String:
+		return stringFormatter
+	case reflect.Int:
+		return intFormatter
+	case reflect.Slice:
+		switch t.Elem().Kind() {
+		case reflect.String:
+			return stringsFormatter
+		case reflect.Int:
+			return intsFormatter
+		default:
+			panic(fmt.Sprintf("No formatter for %v", t))
+		}
+	default:
+		panic(fmt.Sprintf("No formatter for %v", t))
+	}
+}
+
+func boolFormatter(v interface{}) string {
+	return fmt.Sprintf("%v", v)
+}
+
+func stringFormatter(v interface{}) string {
+	return fmt.Sprintf("%#v", v)
+}
+
+func intFormatter(v interface{}) string {
+	return fmt.Sprintf("%v", v)
+}
+
+func stringsFormatter(v interface{}) string {
+	res := "["
+	strings, _ := v.([]string)
+	for idx, s := range strings {
+		if idx > 0 {
+			res += ", "
+		}
+		res += fmt.Sprintf("%#v", s)
+	}
+	return res + "]"
+}
+
+func intsFormatter(v interface{}) string {
+	res := "["
+	ints, _ := v.([]int)
+	for idx, s := range ints {
+		if idx > 0 {
+			res += ", "
+		}
+		res += fmt.Sprintf("%v", s)
+	}
+	return res + "]"
+}

--- a/options.go
+++ b/options.go
@@ -6,15 +6,6 @@ import (
 	"strings"
 )
 
-type opt struct {
-	name      string
-	desc      string
-	envVar    string
-	names     []string
-	value     reflect.Value
-	hideValue bool
-}
-
 // BoolOpt describes a boolean option
 type BoolOpt struct {
 	BoolParam
@@ -167,6 +158,16 @@ func (c *Cmd) IntsOpt(name string, value []int, desc string) *[]int {
 	return c.mkOpt(opt{name: name, desc: desc}, value).(*[]int)
 }
 
+type opt struct {
+	name          string
+	desc          string
+	envVar        string
+	names         []string
+	helpFormatter func(interface{}) string
+	value         reflect.Value
+	hideValue     bool
+}
+
 func (o *opt) isBool() bool {
 	return o.value.Elem().Kind() == reflect.Bool
 }
@@ -197,6 +198,8 @@ func mkOptStrs(optName string) []string {
 func (c *Cmd) mkOpt(opt opt, defaultValue interface{}) interface{} {
 	value := reflect.ValueOf(defaultValue)
 	res := reflect.New(value.Type())
+
+	opt.helpFormatter = formatterFor(value.Type())
 
 	vinit(res, opt.envVar, defaultValue)
 


### PR DESCRIPTION
Till now, mow.cli used go's format string `"%#v"` to print the arg and option values in help messages.

This worked well for ints, bools and strings but produced ugly output for slices:

```
Options:
  -e, --env=[]string(nil)   define an environment variable for the job
```

This PR fixes that by using different formats for the different types.

```
Options:
  -e, --env=[]         define an environment variable for the job
```

The new formats are:

* int: same as before: `0`, `42`, ...
* string: same as before: `""`, `"value"`, ...
* bool: same as before: `true`, `false`
* int slice: `[]`, `[1]`, `[1, 2, 3]`
* string slice: `[]`, `["value"]`, `["value1", "value two"]`