### PR TITLE
Hide the default value of version in help output

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -51,7 +51,12 @@ printing the version string via the CLI.
 
 */
 func (cli *Cli) Version(name, version string) {
-	cli.BoolOpt(name, false, "Show the version and exit")
+	cli.Bool(BoolOpt{
+		Name:      name,
+		Value:     false,
+		Desc:      "Show the version and exit",
+		HideValue: true,
+	})
 	names := mkOptStrs(name)
 	option := cli.optionsIdx[names[0]]
 	cli.version = &cliVersion{version, option}


### PR DESCRIPTION
Minor fix:
rather than display

````
Options:
  --version=false   Show the version and exit
````

leave off the default value

````
Options:
  --version    Show the version and exit
````

Anecdotally (I don't have data to back this up, unfortunately), bool options by convention are assumed false if not specified on the command line and are true if present. If one wants a bool that defaults to true and is toggled false via an option, the conventions I've seen most often are "--no-option" or "--without-option." I do like the option of being explicit and showing the default true/false if the situation or interface makes sense, but prefer "--option" to imply false by default and true if present and "--no-option" to imply true by default, false if not present. Do you agree and is this something you'd be interested in a PR for?