### PR TITLE
Rework the orderless options handling logic

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -46,111 +46,189 @@ func (arg *arg) match(args []string, c *parseContext) (bool, []string) {
 	return true, args[1:]
 }
 
-func (o *opt) match(args []string, c *parseContext) (bool, []string) {
+type optMatcher struct {
+	theOne     *opt
+	optionsIdx map[string]*opt
+}
+
+func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 	if len(args) == 0 || c.rejectOptions {
 		return false, args
 	}
-	arg := args[0]
-	switch {
-	case strings.HasPrefix(arg, "--"):
-		return o.matchLongOpt(args, c)
-	case strings.HasPrefix(arg, "-"):
-		return o.matchShortOpt(args, c)
-	default:
-		return false, args
-	}
-}
 
-func (o *opt) matchLongOpt(args []string, c *parseContext) (bool, []string) {
-	kv := strings.Split(args[0], "=")
-	name := kv[0]
+	idx := 0
+	for idx < len(args) {
+		arg := args[idx]
+		switch {
+		case arg == "-":
+			idx++
+		case arg == "--":
+			return false, nil
+		case strings.HasPrefix(arg, "--"):
+			matched, consumed, nargs := o.matchLongOpt(args, idx, c)
 
-	for _, oname := range o.names {
-		if name == oname {
-			if len(kv) == 2 {
-				c.opts[o] = append(c.opts[o], kv[1])
-				return true, args[1:]
-			}
-			if o.isBool() {
-				c.opts[o] = append(c.opts[o], "true")
-				return true, args[1:]
-			}
-			if len(args) < 2 {
-				return false, args
-			}
-			val := args[1]
-			if strings.HasPrefix(val, "-") {
-				return false, args
-			}
-			c.opts[o] = append(c.opts[o], val)
-			return true, args[2:]
-		}
-	}
-	return false, args
-}
-
-func (o *opt) matchShortOpt(args []string, c *parseContext) (bool, []string) {
-	arg := args[0]
-	if len(arg) < 2 {
-		return false, args
-	}
-	name := arg[0:2]
-	for _, oname := range o.names {
-		if name == oname {
-			switch {
-			case o.isBool():
-
-				if len(arg) == 2 {
-					c.opts[o] = append(c.opts[o], "true")
-
-					return true, args[1:]
-				}
-				rem := arg[2:]
-				if strings.HasPrefix(rem, "=") {
-					c.opts[o] = append(c.opts[o], rem[1:])
-
-					return true, args[1:]
-				}
-
-				c.opts[o] = append(c.opts[o], "true")
-				nargs := make([]string, len(args))
-				nargs[0] = "-" + rem
-				for i := 1; i < len(args); i++ {
-					nargs[i] = args[i]
-				}
+			if matched {
 				return true, nargs
-			default:
-				if len(arg) > 2 {
-					val := arg[2:]
-					if strings.HasPrefix(val, "=") {
-						val = arg[3:]
-					}
-					c.opts[o] = append(c.opts[o], val)
-					return true, args[1:]
-				}
-				if len(args) < 2 {
-					return false, args
-				}
-				val := args[1]
-				if strings.HasPrefix(val, "-") {
-					return false, args
-				}
-				c.opts[o] = append(c.opts[o], val)
-				return true, args[2:]
 			}
+			if consumed == 0 {
+				return false, args
+			}
+			idx += consumed
+
+		case strings.HasPrefix(arg, "-"):
+			matched, consumed, nargs := o.matchShortOpt(args, idx, c)
+
+			if matched {
+				return true, nargs
+			}
+			if consumed == 0 {
+				return false, args
+			}
+			idx += consumed
+
+		default:
+			return false, args
 		}
 	}
 	return false, args
 }
 
-type optsMatcher []*opt
+func (o *optMatcher) matchLongOpt(args []string, idx int, c *parseContext) (bool, int, []string) {
+	arg := args[idx]
+	kv := strings.Split(arg, "=")
+	name := kv[0]
+	opt, found := o.optionsIdx[name]
+	if !found {
+		return false, 0, args
+	}
+
+	switch {
+	case len(kv) == 2:
+		if opt != o.theOne {
+			return false, 1, args
+		}
+		value := kv[1]
+		c.opts[o.theOne] = append(c.opts[o.theOne], value)
+		return true, 1, removeStringAt(idx, args)
+	case opt.isBool():
+		if opt != o.theOne {
+			return false, 1, args
+		}
+		c.opts[o.theOne] = append(c.opts[o.theOne], "true")
+		return true, 1, removeStringAt(idx, args)
+	default:
+		if len(args[idx:]) < 2 {
+			return false, 0, args
+		}
+		if opt != o.theOne {
+			return false, 2, args
+		}
+		value := args[idx+1]
+		if strings.HasPrefix(value, "-") {
+			return false, 0, args
+		}
+		c.opts[o.theOne] = append(c.opts[o.theOne], value)
+		return true, 2, removeStringsBetween(idx, idx+1, args)
+	}
+}
+
+func (o *optMatcher) matchShortOpt(args []string, idx int, c *parseContext) (bool, int, []string) {
+	arg := args[idx]
+	if len(arg) < 2 {
+		return false, 0, args
+	}
+
+	if strings.HasPrefix(arg[2:], "=") {
+		name := arg[0:2]
+		opt, _ := o.optionsIdx[name]
+		if opt == o.theOne {
+			value := arg[3:]
+			if value == "" {
+				return false, 0, args
+			}
+			c.opts[o.theOne] = append(c.opts[o.theOne], value)
+			return true, 1, removeStringAt(idx, args)
+		}
+
+		return false, 1, args
+	}
+
+	rem := arg[1:]
+
+	remIdx := 0
+	for len(rem[remIdx:]) > 0 {
+		name := "-" + rem[remIdx:remIdx+1]
+
+		opt, found := o.optionsIdx[name]
+		if !found {
+			return false, 0, args
+		}
+
+		if opt.isBool() {
+			if opt != o.theOne {
+				remIdx++
+				continue
+			}
+
+			c.opts[o.theOne] = append(c.opts[o.theOne], "true")
+			newRem := rem[:remIdx] + rem[remIdx+1:]
+			if newRem == "" {
+				return true, 1, removeStringAt(idx, args)
+			}
+			return true, 0, replaceStringAt(idx, "-"+newRem, args)
+		}
+
+		value := rem[remIdx+1:]
+		if value == "" {
+			if len(args[idx+1:]) == 0 {
+				return false, 0, args
+			}
+			if opt != o.theOne {
+				return false, 2, args
+			}
+
+			value = args[idx+1]
+			if strings.HasPrefix(value, "-") {
+				return false, 0, args
+			}
+			c.opts[o.theOne] = append(c.opts[o.theOne], value)
+
+			newRem := rem[:remIdx]
+			if newRem == "" {
+				return true, 2, removeStringsBetween(idx, idx+1, args)
+			}
+
+			nargs := replaceStringAt(idx, "-"+newRem, args)
+
+			return true, 1, removeStringAt(idx+1, nargs)
+		}
+
+		if opt != o.theOne {
+			return false, 1, args
+		}
+		c.opts[o.theOne] = append(c.opts[o.theOne], value)
+		newRem := rem[:remIdx]
+		if newRem == "" {
+			return true, 1, removeStringAt(idx, args)
+		}
+		return true, 0, replaceStringAt(idx, "-"+newRem, args)
+
+	}
+
+	return false, 1, args
+}
+
+type optsMatcher struct {
+	options      []*opt
+	optionsIndex map[string]*opt
+}
 
 func (om optsMatcher) try(args []string, c *parseContext) (bool, []string) {
 	if len(args) == 0 || c.rejectOptions {
 		return false, args
 	}
-	for _, o := range om {
-		if ok, nargs := o.match(args, c); ok {
+	for _, o := range om.options {
+		if ok, nargs := (&optMatcher{theOne: o, optionsIdx: om.optionsIndex}).match(args, c); ok {
 			return ok, nargs
 		}
 	}
@@ -173,6 +251,27 @@ func (om optsMatcher) match(args []string, c *parseContext) (bool, []string) {
 }
 
 func (om optsMatcher) String() string {
-	return fmt.Sprintf("Opts(%v)", []*opt(om))
+	return fmt.Sprintf("Opts(%v)", om.options)
+}
 
+func removeStringAt(idx int, arr []string) []string {
+	res := make([]string, len(arr)-1)
+	copy(res, arr[:idx])
+	copy(res[idx:], arr[idx+1:])
+	return res
+}
+
+func removeStringsBetween(from, to int, arr []string) []string {
+	res := make([]string, len(arr)-(to-from+1))
+	copy(res, arr[:from])
+	copy(res[from:], arr[to+1:])
+	return res
+}
+
+func replaceStringAt(idx int, with string, arr []string) []string {
+	res := make([]string, len(arr))
+	copy(res, arr[:idx])
+	res[idx] = with
+	copy(res[idx+1:], arr[idx+1:])
+	return res
 }

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -49,8 +49,17 @@ func TestArgMatcher(t *testing.T) {
 }
 
 func TestBoolOptMatcher(t *testing.T) {
-	opt := &opt{names: []string{"-f", "--force"}, value: reflect.New(reflect.TypeOf(true))}
-
+	forceOpt := &opt{names: []string{"-f", "--force"}, value: reflect.New(reflect.TypeOf(true))}
+	optMatcher := &optMatcher{
+		theOne: forceOpt,
+		optionsIdx: map[string]*opt{
+			"-f":      forceOpt,
+			"--force": forceOpt,
+			"-g":      &opt{names: []string{"-g"}, value: reflect.New(reflect.TypeOf(true))},
+			"-x":      &opt{names: []string{"-x"}, value: reflect.New(reflect.TypeOf(true))},
+			"-y":      &opt{names: []string{"-y"}, value: reflect.New(reflect.TypeOf(true))},
+		},
+	}
 	cases := []struct {
 		args  []string
 		nargs []string
@@ -63,17 +72,20 @@ func TestBoolOptMatcher(t *testing.T) {
 		{[]string{"--force=true", "x"}, []string{"x"}, []string{"true"}},
 		{[]string{"--force=false", "x"}, []string{"x"}, []string{"false"}},
 		{[]string{"-fgxy", "x"}, []string{"-gxy", "x"}, []string{"true"}},
+		{[]string{"-gfxy", "x"}, []string{"-gxy", "x"}, []string{"true"}},
+		{[]string{"-gxfy", "x"}, []string{"-gxy", "x"}, []string{"true"}},
+		{[]string{"-gxyf", "x"}, []string{"-gxy", "x"}, []string{"true"}},
 	}
 	for _, cas := range cases {
 		pc := newParseContext()
-		ok, nargs := opt.match(cas.args, &pc)
+		ok, nargs := optMatcher.match(cas.args, &pc)
 		require.True(t, ok, "opt should match")
 		require.Equal(t, cas.nargs, nargs, "opt should consume the option name")
-		require.Equal(t, cas.val, pc.opts[opt], "true should stored as the option's value")
+		require.Equal(t, cas.val, pc.opts[forceOpt], "true should stored as the option's value")
 
 		pc = newParseContext()
 		pc.rejectOptions = true
-		nok, _ := opt.match(cas.args, &pc)
+		nok, _ := optMatcher.match(cas.args, &pc)
 		require.False(t, nok, "opt shouldn't match when rejectOptions flag is set")
 	}
 }
@@ -95,21 +107,32 @@ func TestOptMatcher(t *testing.T) {
 		{[]string{"-f", "x"}, []string{}, []string{"x"}},
 		{[]string{"-f=x", "y"}, []string{"y"}, []string{"x"}},
 		{[]string{"-fx", "y"}, []string{"y"}, []string{"x"}},
+		{[]string{"-afx", "y"}, []string{"-a", "y"}, []string{"x"}},
+		{[]string{"-af", "x", "y"}, []string{"-a", "y"}, []string{"x"}},
 		{[]string{"--force", "x"}, []string{}, []string{"x"}},
 		{[]string{"--force=x", "y"}, []string{"y"}, []string{"x"}},
 	}
 
 	for _, cas := range cases {
-		for _, opt := range opts {
+		for _, forceOpt := range opts {
+			optMatcher := &optMatcher{
+				theOne: forceOpt,
+				optionsIdx: map[string]*opt{
+					"-f":      forceOpt,
+					"--force": forceOpt,
+					"-a":      &opt{names: []string{"-a"}, value: reflect.New(reflect.TypeOf(true))},
+				},
+			}
+
 			pc := newParseContext()
-			ok, nargs := opt.match(cas.args, &pc)
+			ok, nargs := optMatcher.match(cas.args, &pc)
 			require.True(t, ok, "opt should match")
 			require.Equal(t, cas.nargs, nargs, "opt should consume the option name")
-			require.Equal(t, cas.val, pc.opts[opt], "true should stored as the option's value")
+			require.Equal(t, cas.val, pc.opts[forceOpt], "true should stored as the option's value")
 
 			pc = newParseContext()
 			pc.rejectOptions = true
-			nok, _ := opt.match(cas.args, &pc)
+			nok, _ := optMatcher.match(cas.args, &pc)
 			require.False(t, nok, "opt shouldn't match when rejectOptions flag is set")
 		}
 	}
@@ -117,8 +140,17 @@ func TestOptMatcher(t *testing.T) {
 
 func TestOptsMatcher(t *testing.T) {
 	opts := optsMatcher{
-		&opt{names: []string{"-f", "--force"}, value: reflect.New(reflect.TypeOf(true))},
-		&opt{names: []string{"-g", "--green"}, value: reflect.New(reflect.TypeOf(""))},
+		options: []*opt{
+			{names: []string{"-f", "--force"}, value: reflect.New(reflect.TypeOf(true))},
+			{names: []string{"-g", "--green"}, value: reflect.New(reflect.TypeOf(""))},
+		},
+		optionsIndex: map[string]*opt{},
+	}
+
+	for _, o := range opts.options {
+		for _, n := range o.names {
+			opts.optionsIndex[n] = o
+		}
 	}
 
 	cases := []struct {
@@ -149,7 +181,7 @@ func TestOptsMatcher(t *testing.T) {
 		ok, nargs := opts.match(cas.args, &pc)
 		require.True(t, ok, "opts should match")
 		require.Equal(t, cas.nargs, nargs, "opts should consume the option name")
-		for i, opt := range opts {
+		for i, opt := range opts.options {
 			require.Equal(t, cas.val[i], pc.opts[opt], "the option value for %v should be stored", opt)
 		}
 

--- a/spec_n_parse_test.go
+++ b/spec_n_parse_test.go
@@ -41,11 +41,11 @@ func failCmd(t *testing.T, spec string, init CmdInitializer, args []string) {
 	init(cmd)
 
 	err := cmd.doInit()
-	require.Nil(t, err, "should parse")
+	require.NoError(t, err, "should parse")
 	t.Logf("testing spec %s with args: %v", spec, args)
 	inFlow := &step{}
 	err = cmd.parse(args, inFlow, inFlow, &step{})
-	require.NotNil(t, err, "cmd parse should have failed")
+	require.Error(t, err, "cmd parse should have failed")
 }
 
 func badSpec(t *testing.T, spec string, init CmdInitializer) {
@@ -1162,4 +1162,41 @@ func TestSpecOptInlineValue(t *testing.T) {
 	require.Equal(t, "a", *x)
 	require.Equal(t, "g", *g)
 	require.Equal(t, []string{"b"}, *y)
+}
+
+// https://github.com/jawher/mow.cli/issues/28
+func TestWardDoesntRunTooSlowly(t *testing.T) {
+	init := func(cmd *Cmd) {
+		_ = cmd.StringOpt("login", "", "Login for credential, e.g. username or email.")
+		_ = cmd.StringOpt("realm", "", "Realm for credential, e.g. website or WiFi AP name.")
+		_ = cmd.StringOpt("note", "", "Note for credential.")
+		_ = cmd.BoolOpt("no-copy", false, "Do not copy generated password to the clipboard.")
+		_ = cmd.BoolOpt("gen", false, "Generate a password.")
+		_ = cmd.IntOpt("length", 0, "Password length.")
+		_ = cmd.IntOpt("min-length", 30, "Minimum length password.")
+		_ = cmd.IntOpt("max-length", 40, "Maximum length password.")
+		_ = cmd.BoolOpt("no-upper", false, "Exclude uppercase characters in password.")
+		_ = cmd.BoolOpt("no-lower", false, "Exclude lowercase characters in password.")
+		_ = cmd.BoolOpt("no-digit", false, "Exclude digit characters in password.")
+		_ = cmd.BoolOpt("no-symbol", false, "Exclude symbol characters in password.")
+		_ = cmd.BoolOpt("no-similar", false, "Exclude similar characters in password.")
+		_ = cmd.IntOpt("min-upper", 0, "Minimum number of uppercase characters in password.")
+		_ = cmd.IntOpt("max-upper", -1, "Maximum number of uppercase characters in password.")
+		_ = cmd.IntOpt("min-lower", 0, "Minimum number of lowercase characters in password.")
+		_ = cmd.IntOpt("max-lower", -1, "Maximum number of lowercase characters in password.")
+		_ = cmd.IntOpt("min-digit", 0, "Minimum number of digit characters in password.")
+		_ = cmd.IntOpt("max-digit", -1, "Maximum number of digit characters in password.")
+		_ = cmd.IntOpt("min-symbol", 0, "Minimum number of symbol characters in password.")
+		_ = cmd.IntOpt("max-symbol", -1, "Maximum number of symbol characters in password.")
+		_ = cmd.StringOpt("exclude", "", "Exclude specific characters from password.")
+	}
+
+	spec := "[--login] [--realm] [--note] [--no-copy] [--gen [--length] [--min-length] [--max-length] [--no-upper] [--no-lower] [--no-digit] [--no-symbol] [--no-similar] [--min-upper] [--max-upper] [--min-lower] [--max-lower] [--min-digit] [--max-digit] [--min-symbol] [--max-symbol] [--exclude]]"
+
+	okCmd(t, spec, init, []string{})
+	okCmd(t, spec, init, []string{"--gen", "--length", "42"})
+	okCmd(t, spec, init, []string{"--length", "42", "--gen"})
+	okCmd(t, spec, init, []string{"--min-length", "10", "--length", "42", "--gen"})
+	okCmd(t, spec, init, []string{"--min-length", "10", "--no-symbol", "--no-lower", "--length", "42", "--gen"})
+
 }


### PR DESCRIPTION
Previously, mow.cli used to handle the orderless nature of options in
a, shall we say "not a very smart way" ?

The sequence parser, if two consecutive elements A and B only contain options,
a new FSM accepting "A then B" and "B then A" was constructed.

For 3 options-only elements, this would amount to 6 possible
combinations, 24 for 4 elemnts, etc.

The time and memory compexity of this rapidly grows on a factorial of
the number of options.

The proposed fix here attacks the problem the other way around:
instead of tweaking the FSM to accept the options in any order, the FSM
is kept as is, but matching an option would look over all the
arguments, and not just the first.

Given a spec string:

`-f -g`

The generated FSM would look like this:

`S0--[-f]-->S1--[-g]-->(S2)`

When applied to a user input of `-g -f`, the first transition (`S1-->S2`, which only succeeds if the `-f` option is encountered)
would check the args one by one until it finds a match, or fail
otherwise.

Fixes #28