### PR TITLE
Allow required options to be satisfied by env var

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -53,7 +53,7 @@ type optMatcher struct {
 
 func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 	if len(args) == 0 || c.rejectOptions {
-		return false, args
+		return o.theOne.envSet, args
 	}
 
 	idx := 0
@@ -63,7 +63,7 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 		case arg == "-":
 			idx++
 		case arg == "--":
-			return false, nil
+			return o.theOne.envSet, nil
 		case strings.HasPrefix(arg, "--"):
 			matched, consumed, nargs := o.matchLongOpt(args, idx, c)
 
@@ -71,7 +71,7 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 				return true, nargs
 			}
 			if consumed == 0 {
-				return false, args
+				return o.theOne.envSet, args
 			}
 			idx += consumed
 
@@ -82,15 +82,15 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 				return true, nargs
 			}
 			if consumed == 0 {
-				return false, args
+				return o.theOne.envSet, args
 			}
 			idx += consumed
 
 		default:
-			return false, args
+			return o.theOne.envSet, args
 		}
 	}
-	return false, args
+	return o.theOne.envSet, args
 }
 
 func (o *optMatcher) matchLongOpt(args []string, idx int, c *parseContext) (bool, int, []string) {

--- a/options.go
+++ b/options.go
@@ -165,6 +165,7 @@ type opt struct {
 	names         []string
 	helpFormatter func(interface{}) string
 	value         reflect.Value
+	envSet        bool
 	hideValue     bool
 }
 
@@ -201,7 +202,7 @@ func (c *Cmd) mkOpt(opt opt, defaultValue interface{}) interface{} {
 
 	opt.helpFormatter = formatterFor(value.Type())
 
-	vinit(res, opt.envVar, defaultValue)
+	opt.envSet = vinit(res, opt.envVar, defaultValue)
 
 	opt.names = mkOptStrs(opt.name)
 	opt.value = res

--- a/reflect.go
+++ b/reflect.go
@@ -60,7 +60,7 @@ func vset(into reflect.Value, s string) error {
 	return nil
 }
 
-func vinit(into reflect.Value, envVars string, defaultValue interface{}) {
+func vinit(into reflect.Value, envVars string, defaultValue interface{}) (envSet bool) {
 	if len(envVars) > 0 {
 		for _, rev := range strings.Split(envVars, " ") {
 			ev := strings.TrimSpace(rev)
@@ -70,7 +70,7 @@ func vinit(into reflect.Value, envVars string, defaultValue interface{}) {
 					conv, err := vconv(v, into.Elem().Type())
 					if err == nil {
 						into.Elem().Set(conv)
-						return
+						return true
 					}
 				}
 			}
@@ -78,4 +78,5 @@ func vinit(into reflect.Value, envVars string, defaultValue interface{}) {
 
 	}
 	into.Elem().Set(reflect.ValueOf(defaultValue))
+	return false
 }


### PR DESCRIPTION
re #33 - I doubt this is the correct approach, but was playing around with the code for fun and thought you'd like to take a look.

If i read the code correctly, this should allow fallback to an environment variable for options only (it doesn't make sense to fall back to an env var for a required argument, i think) and seems to do the right thing without requiring updating the state machine itself.  The extra envSet flag is required to avoid falling back to a default value that wasn't supplied by the environment.

One problem, which i think is unrelated to this change, is that using a repeating option with an environment variable causes the options on the command line to be added to the values supplied by the environment variable, rather than overriding it
