### PR TITLE
Fix infinite loop case for envvar backed opts

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -53,7 +53,7 @@ type optMatcher struct {
 
 func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 	if len(args) == 0 || c.rejectOptions {
-		return o.theOne.valueSetFromEnv, args
+		return false, args
 	}
 
 	idx := 0
@@ -63,7 +63,7 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 		case arg == "-":
 			idx++
 		case arg == "--":
-			return o.theOne.valueSetFromEnv, nil
+			return false, nil
 		case strings.HasPrefix(arg, "--"):
 			matched, consumed, nargs := o.matchLongOpt(args, idx, c)
 
@@ -71,7 +71,7 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 				return true, nargs
 			}
 			if consumed == 0 {
-				return o.theOne.valueSetFromEnv, args
+				return false, args
 			}
 			idx += consumed
 
@@ -81,15 +81,15 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 				return true, nargs
 			}
 			if consumed == 0 {
-				return o.theOne.valueSetFromEnv, args
+				return false, args
 			}
 			idx += consumed
 
 		default:
-			return o.theOne.valueSetFromEnv, args
+			return false, args
 		}
 	}
-	return o.theOne.valueSetFromEnv, args
+	return false, args
 }
 
 func (o *optMatcher) matchLongOpt(args []string, idx int, c *parseContext) (bool, int, []string) {
@@ -215,6 +215,15 @@ func (o *optMatcher) matchShortOpt(args []string, idx int, c *parseContext) (boo
 	}
 
 	return false, 1, args
+}
+
+type optOrEnvMatcher struct {
+	optMatcher
+}
+
+func (o *optOrEnvMatcher) match(args []string, c *parseContext) (bool, []string) {
+	ok, args := o.optMatcher.match(args, c)
+	return ok || o.theOne.valueSetFromEnv, args
 }
 
 type optsMatcher struct {

--- a/spec_n_parse_test.go
+++ b/spec_n_parse_test.go
@@ -1254,6 +1254,31 @@ func TestEnvOverrideOk(t *testing.T) {
 	}
 }
 
+func TestEnvOptSeq(t *testing.T) {
+	defer os.Unsetenv("envopt")
+
+	var envopt *string
+	var arg *string
+
+	init := func(c *Cmd) {
+		defer os.Unsetenv("envopt")
+
+		envopt = c.String(StringOpt{
+			Name:   "e envopt",
+			Value:  "envdefault",
+			EnvVar: "envopt",
+		})
+
+		arg = c.StringArg("ARG", "", "")
+	}
+
+	os.Setenv("envopt", "envval")
+	okCmd(t, "", init, []string{"argval"})
+
+	assert.Equal(t, "envval", *envopt)
+	assert.Equal(t, "argval", *arg)
+}
+
 // Test that not setting an environment variable correctly causes
 // required options to fail if no value is supplied in args.
 func TestEnvOverrideFail(t *testing.T) {

--- a/spec_parser.go
+++ b/spec_parser.go
@@ -123,9 +123,11 @@ func (p *uParser) atom() (*state, *state) {
 			p.back()
 			panic(fmt.Sprintf("Undeclared option %s", name))
 		}
-		end = start.t(&optMatcher{
-			theOne:     opt,
-			optionsIdx: p.cmd.optionsIdx,
+		end = start.t(&optOrEnvMatcher{
+			optMatcher: optMatcher{
+				theOne:     opt,
+				optionsIdx: p.cmd.optionsIdx,
+			},
 		}, newState(p.cmd))
 		p.found(utOptValue)
 	case p.found(utLongOpt):
@@ -139,9 +141,11 @@ func (p *uParser) atom() (*state, *state) {
 			p.back()
 			panic(fmt.Sprintf("Undeclared option %s", name))
 		}
-		end = start.t(&optMatcher{
-			theOne:     opt,
-			optionsIdx: p.cmd.optionsIdx,
+		end = start.t(&optOrEnvMatcher{
+			optMatcher: optMatcher{
+				theOne:     opt,
+				optionsIdx: p.cmd.optionsIdx,
+			},
 		}, newState(p.cmd))
 		p.found(utOptValue)
 	case p.found(utOptSeq):


### PR DESCRIPTION
I think my original approach to implement required options fulfilled by environment variables took a wrong approach, as it can cause `optsmatcher` to be throw into an infinite loop:

```golang
func main() {
        app := cli.App("app", "app")

        arg := app.StringArg("ARG", "", "")

        opt := app.String(cli.StringOpt{
                Name:   "opt",
                EnvVar: "OPT",
        })

        app.Action = func() {
                fmt.Println("arg", *arg)
                fmt.Println("opt", *opt)
        }

        app.Run(os.Args)
}
```

The above will never exit if you run it as `OPT=something go run test.go myarg`


In practice, optsmatcher should not fall back an environment variable as a
requirement for an option during a transition; doing so may cause
optsmatcher.match to never exit as the generated optmatcher will always
return true, even when it doesn't consume any arguments.

Instead I created a new optOrEnvMatcher for use in cases where falling back to an
environment variable satisfies the requirement condition.