### PR TITLE
Fix infinite loop in options matching

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -86,10 +86,6 @@ func (o *optMatcher) match(args []string, c *parseContext) (bool, []string) {
 			idx += consumed
 
 		default:
-			if o.theOne.valueSetFromEnv {
-				//  exclude opt
-				c.excludedOpts[o.theOne] = struct{}{}
-			}
 			return o.theOne.valueSetFromEnv, args
 		}
 	}
@@ -235,7 +231,10 @@ func (om optsMatcher) try(args []string, c *parseContext) (bool, []string) {
 			continue
 		}
 		if ok, nargs := (&optMatcher{theOne: o, optionsIdx: om.optionsIndex}).match(args, c); ok {
-			return ok, nargs
+			if o.valueSetFromEnv {
+				c.excludedOpts[o] = struct{}{}
+			}
+			return true, nargs
 		}
 	}
 	return false, args


### PR DESCRIPTION
This is a bug in `optsMatcher` (i.e. `[OPTIONS]`).
This bug happens when:

* At least one option is declared with an env var name
* The said env var is set
* An invalid option name is passed to the `optsMatcher`

The bug explanation:

`optsMatcher` has a `for {}` loop, which runs until no option matches anymore.
Since options set from an env variables would always match, and to avoid
an infinite loop, a fix was added in #50 where an `optMatcher` would add
its option to an exlusion list when set from env, and `optsMatcher`
would skip options in this exclude list.

This fix was not enough: if called with an invalid option, the code path
to exclude an option is not executed.

This fix moves the exclusion of options to `optsMatcher`, which
incidentally is always run, regardless of which code path was followd.

Fixes #55