### PR TITLE
A possible way to add enums

### DIFF
--- a/args.go
+++ b/args.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/jawher/mow.cli/internal/container"
 	"github.com/jawher/mow.cli/internal/values"
@@ -24,6 +25,29 @@ type BoolArg struct {
 }
 
 func (a BoolArg) value() bool {
+	return a.Value
+}
+
+// EnumArg describes a string option
+type EnumArg struct {
+	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
+	// The one letter names will then be called with a single dash (short option), the others with two (long options).
+	Name string
+	// The option description as will be shown in help messages
+	Desc string
+	// A space separated list of environment variables names to be used to initialize this option
+	EnvVar string
+	// The option's initial value
+	Value string
+	// A boolean to display or not the current value of the option in the help message
+	HideValue bool
+	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
+	SetByUser *bool
+	// Enums contains the enum values
+	Validation []EnumValidator
+}
+
+func (a EnumArg) value() string {
 	return a.Value
 }
 
@@ -140,6 +164,24 @@ func (c *Cmd) BoolArg(name string, value bool, desc string) *bool {
 		Name:  name,
 		Value: value,
 		Desc:  desc,
+	})
+}
+
+/*
+EnumArg defines an enum argument on the command c named `name`, with an initial value of `value` and a description of `desc` which will be used in help messages.
+
+The result should be stored in a variable (a pointer to a string) which will be populated when the app is run and the call arguments get parsed
+*/
+func (c *Cmd) EnumArg(name, value, desc string, validation []EnumValidator) *string {
+	if validation == nil || len(validation) == 0 {
+		panic(fmt.Sprintf("Enums require validation %s %s", name, value))
+	}
+
+	return c.Enum(EnumArg{
+		Name:       name,
+		Value:      value,
+		Desc:       desc,
+		Validation: validation,
 	})
 }
 

--- a/args.go
+++ b/args.go
@@ -247,6 +247,10 @@ func (c *Cmd) VarArg(name string, value flag.Value, desc string) {
 }
 
 func (c *Cmd) mkArg(arg container.Container) {
+	arg.DefaultValue = arg.Value.String()
+	if dv, ok := arg.Value.(values.DefaultValued); ok {
+		arg.DefaultDisplay = dv.IsDefault()
+	}
 	arg.ValueSetFromEnv = values.SetFromEnv(arg.Value, arg.EnvVar)
 
 	c.args = append(c.args, &arg)

--- a/cli_test.go
+++ b/cli_test.go
@@ -774,6 +774,45 @@ func TestOptSetByUser(t *testing.T) {
 			expected: true,
 		},
 
+		// Enum
+		{
+			desc: "Enum Opt, not set by user, default value",
+			config: func(c *Cli, s *bool) {
+				c.Enum(EnumOpt{Name: "f", Value: "v1", SetByUser: s,
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: false,
+		},
+		{
+			desc: "Enum Opt, not set by user, env value",
+			config: func(c *Cli, s *bool) {
+				os.Setenv("MOW_VALUE", "v2")
+				c.Enum(EnumOpt{Name: "f", EnvVar: "MOW_VALUE", SetByUser: s,
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: false,
+		},
+		{
+			desc: "Enum Opt, set by user",
+			config: func(c *Cli, s *bool) {
+				c.Enum(EnumOpt{Name: "f", Value: "a", SetByUser: s,
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test", "-f=v2"},
+			expected: true,
+		},
+
 		// Bool
 		{
 			desc: "Bool Opt, not set by user, default value",
@@ -938,6 +977,48 @@ func TestArgSetByUser(t *testing.T) {
 				c.String(StringArg{Name: "ARG", Value: "a", SetByUser: s})
 			},
 			args:     []string{"test", "aaa"},
+			expected: true,
+		},
+
+		// Enum
+		{
+			desc: "Enum Arg, not set by user, default value",
+			config: func(c *Cli, s *bool) {
+				c.Spec = "[ARG]"
+				c.Enum(EnumArg{Name: "ARG", Value: "v1", SetByUser: s,
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: false,
+		},
+		{
+			desc: "Enum Arg, not set by user, env value",
+			config: func(c *Cli, s *bool) {
+				c.Spec = "[ARG]"
+				os.Setenv("MOW_VALUE", "v2")
+				c.Enum(EnumArg{Name: "ARG", EnvVar: "MOW_VALUE", SetByUser: s,
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: false,
+		},
+		{
+			desc: "Enum Arg, set by user",
+			config: func(c *Cli, s *bool) {
+				c.Spec = "[ARG]"
+				c.Enum(EnumArg{Name: "ARG", Value: "a", SetByUser: s,
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test", "v2"},
 			expected: true,
 		},
 
@@ -1118,6 +1199,48 @@ func TestOptSetByEnv(t *testing.T) {
 			},
 			args:     []string{"test", "-f=user"},
 			expected: "user",
+		},
+
+		// Enum
+		{
+			desc: "Enum Opt, empty env var",
+			config: func(c *Cli) interface{} {
+				os.Setenv("MOW_VALUE", "")
+				return c.Enum(EnumOpt{Name: "f", Value: "v1", EnvVar: "MOW_VALUE",
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: "1",
+		},
+		{
+			desc: "Enum Opt, env set, not set by user",
+			config: func(c *Cli) interface{} {
+				os.Setenv("MOW_VALUE", "v2")
+				return c.Enum(EnumOpt{Name: "f", Value: "v1", EnvVar: "MOW_VALUE",
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: "2",
+		},
+		{
+			desc: "Enum Opt, env set, set by user",
+			config: func(c *Cli) interface{} {
+				os.Setenv("MOW_VALUE", "v2")
+				return c.Enum(EnumOpt{Name: "f", Value: "v1", EnvVar: "MOW_VALUE",
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+						{User: "v3", Value: "3", Help: "v3"},
+					}})
+			},
+			args:     []string{"test", "-f=v3"},
+			expected: "3",
 		},
 
 		// Bool
@@ -1369,6 +1492,51 @@ func TestArgSetByEnv(t *testing.T) {
 			},
 			args:     []string{"test", "user"},
 			expected: "user",
+		},
+
+		// Enum
+		{
+			desc: "Enum Arg, empty env var",
+			config: func(c *Cli) interface{} {
+				c.Spec = "[ARG]"
+				os.Setenv("MOW_VALUE", "")
+				return c.Enum(EnumArg{Name: "ARG", Value: "v1", EnvVar: "MOW_VALUE",
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: "1",
+		},
+		{
+			desc: "Enum Arg, env set, not set by user",
+			config: func(c *Cli) interface{} {
+				c.Spec = "[ARG]"
+				os.Setenv("MOW_VALUE", "v2")
+				return c.Enum(EnumArg{Name: "ARG", Value: "default", EnvVar: "MOW_VALUE",
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+					}})
+			},
+			args:     []string{"test"},
+			expected: "2",
+		},
+		{
+			desc: "Enum Arg, env set, set by user",
+			config: func(c *Cli) interface{} {
+				c.Spec = "[ARG]"
+				os.Setenv("MOW_VALUE", "v2")
+				return c.Enum(EnumArg{Name: "ARG", Value: "v1", EnvVar: "MOW_VALUE",
+					Validation: []EnumValidator{
+						{User: "v1", Value: "1", Help: "v1"},
+						{User: "v2", Value: "2", Help: "v2"},
+						{User: "v3", Value: "3", Help: "v3"},
+					}})
+			},
+			args:     []string{"test", "v3"},
+			expected: "3",
 		},
 
 		// Bool

--- a/cli_test.go
+++ b/cli_test.go
@@ -465,6 +465,24 @@ func TestHelpMessage(t *testing.T) {
 	app.String(StringOpt{Name: "str2", Value: "a value", Desc: "String Option 2"})
 	app.String(StringOpt{Name: "u", Value: "another value", EnvVar: "STR3", Desc: "String Option 3", HideValue: true})
 
+	app.Enum(EnumOpt{Name: "e enum1", Value: "", EnvVar: "ENUM1", Desc: "Enum Option 1", Validation: []EnumValidator{
+		{User: "value1", Value: "v1", Help: "Option 1 value 1"},
+		{User: "value2", Value: "v2", Help: "Option 1 value 2"},
+		{User: "value3", Value: "v3", Help: "Option 1 value 3"},
+	}})
+
+	app.Enum(EnumOpt{Name: "enum2", Value: "a value", Desc: "Enum Option 2", Validation: []EnumValidator{
+		{User: "value1", Value: "v1", Help: "Option 2 value 1"},
+		{User: "value2", Value: "v2", Help: "Option 2 value 2"},
+		{User: "value3", Value: "v3", Help: "Option 2 value 3"},
+	}})
+
+	app.Enum(EnumOpt{Name: "f", Value: "another value", EnvVar: "ENUM3", Desc: "Enum Option 3", HideValue: true, Validation: []EnumValidator{
+		{User: "value1", Value: "v1", Help: "Option 3 value 1"},
+		{User: "value2", Value: "v2", Help: "Option 3 value 2"},
+		{User: "value3", Value: "v3", Help: "Option 3 value 3"},
+	}})
+
 	app.Int(IntOpt{Name: "i int1", Value: 0, EnvVar: "INT1 ALIAS_INT1"})
 	app.Int(IntOpt{Name: "int2", Value: 1, EnvVar: "INT2", Desc: "Int Option 2"})
 	app.Int(IntOpt{Name: "k", Value: 1, EnvVar: "INT3", Desc: "Int Option 3", HideValue: true})
@@ -485,6 +503,24 @@ func TestHelpMessage(t *testing.T) {
 	app.String(StringArg{Name: "STR1", Value: "", EnvVar: "STR1", Desc: "String Argument 1"})
 	app.String(StringArg{Name: "STR2", Value: "a value", EnvVar: "STR2", Desc: "String Argument 2"})
 	app.String(StringArg{Name: "STR3", Value: "another value", EnvVar: "STR3", Desc: "String Argument 3", HideValue: true})
+
+	app.Enum(EnumArg{Name: "ENUM1", Value: "", EnvVar: "ENUM1", Desc: "Enum Argument 1", Validation: []EnumValidator{
+		{User: "value1", Value: "v1", Help: "Argument 1 value 1"},
+		{User: "value2", Value: "v2", Help: "Argument 1 value 2"},
+		{User: "value3", Value: "v3", Help: "Argument 1 value 3"},
+	}})
+
+	app.Enum(EnumArg{Name: "ENUM1", Value: "a value", Desc: "Enum Argument 2", Validation: []EnumValidator{
+		{User: "value1", Value: "v1", Help: "Argument 2 value 1"},
+		{User: "value2", Value: "v2", Help: "Argument 2 value 2"},
+		{User: "value3", Value: "v3", Help: "Argument 2 value 3"},
+	}})
+
+	app.Enum(EnumArg{Name: "ENUM3", Value: "another value", EnvVar: "ENUM3", Desc: "Enum Argument 3", HideValue: true, Validation: []EnumValidator{
+		{User: "value1", Value: "v1", Help: "Argument 3 value 1"},
+		{User: "value2", Value: "v2", Help: "Argument 3 value 2"},
+		{User: "value3", Value: "v3", Help: "Argument 3 value 3"},
+	}})
 
 	app.Int(IntArg{Name: "INT1", Value: 0, EnvVar: "INT1", Desc: "Int Argument 1"})
 	app.Int(IntArg{Name: "INT2", Value: 1, EnvVar: "INT2", Desc: "Int Argument 2"})

--- a/commands.go
+++ b/commands.go
@@ -398,7 +398,7 @@ func (c *Cmd) printHelp(longDesc bool) {
 		for _, arg := range c.args {
 			var (
 				env        = formatEnvVarsForHelp(arg.EnvVar)
-				value      = formatValueForHelp(arg.HideValue, arg.Value)
+				value      = formatValueForHelp(arg.HideValue, arg.DefaultDisplay, arg.DefaultValue)
 				additional = formatExtraForHelp(arg.HideValue, arg)
 			)
 			fmt.Fprintf(w, "  %s\t%s\n", arg.Name, joinStrings(arg.Desc, env, value, additional))
@@ -412,7 +412,7 @@ func (c *Cmd) printHelp(longDesc bool) {
 			var (
 				optNames   = formatOptNamesForHelp(opt)
 				env        = formatEnvVarsForHelp(opt.EnvVar)
-				value      = formatValueForHelp(opt.HideValue, opt.Value)
+				value      = formatValueForHelp(opt.HideValue, opt.DefaultDisplay, opt.DefaultValue)
 				additional = formatExtraForHelp(opt.HideValue, opt)
 			)
 			fmt.Fprintf(w, "  %s\t%s\n", optNames, joinStrings(opt.Desc, env, value, additional))
@@ -473,18 +473,16 @@ func formatExtraForHelp(hide bool, c *container.Container) string {
 	return extra
 }
 
-func formatValueForHelp(hide bool, v flag.Value) string {
+func formatValueForHelp(hide bool, dontDisplay bool, vp string) string {
 	if hide {
 		return ""
 	}
 
-	if dv, ok := v.(values.DefaultValued); ok {
-		if dv.IsDefault() {
-			return ""
-		}
+	if dontDisplay {
+		return ""
 	}
 
-	return fmt.Sprintf("(default %s)", v.String())
+	return fmt.Sprintf("(default %s)", vp)
 }
 
 func formatEnvVarsForHelp(envVars string) string {

--- a/commands.go
+++ b/commands.go
@@ -545,7 +545,7 @@ func (c *Cmd) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
 	// a valid commandline value
 	for _, curr := range []([]*container.Container){c.args, c.options} {
 		for _, op := range curr {
-			if op.ValueSetFromEnv && op.Validation != nil {
+			if op.Validation != nil {
 				switch x := op.Value.(type) {
 				case values.EnumValued:
 					vc, err := x.Validate(x.RealString(), op.Validation)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -2,6 +2,44 @@ package container
 
 import "flag"
 
+// ValidationType is the type of validation supported for this field
+type ValidationType int
+
+const (
+	// Enum is for enum validation, espected to set User/Value/Help
+	Enum ValidationType = iota
+
+	// TODO:
+	// IPv4Address
+	// IPv6Address
+	// IPv4Network
+	// IPv6Network
+	// IntRange
+)
+
+/*
+Validation contains information needed to validate the value provided by the
+user
+*/
+type Validator struct {
+	Type ValidationType
+
+	// TODO:
+	// IntMin int
+	// IntMax max
+	// ...
+
+	// Enums
+	// User is the value the user can pass
+	User string
+	// Value is the value assigned to the string for this user value
+	Value string
+	// Help is the help message for this value
+	Help string
+	// Callback is called if the user passes this value to the enum
+	Callback func() error
+}
+
 /*
 Container holds an option or an arg data
 */
@@ -14,4 +52,5 @@ type Container struct {
 	ValueSetFromEnv bool
 	ValueSetByUser  *bool
 	Value           flag.Value
+	Validation      []Validator
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -52,5 +52,7 @@ type Container struct {
 	ValueSetFromEnv bool
 	ValueSetByUser  *bool
 	Value           flag.Value
+	DefaultValue    string
+	DefaultDisplay  bool
 	Validation      []Validator
 }

--- a/internal/fsm/fsm.go
+++ b/internal/fsm/fsm.go
@@ -137,6 +137,20 @@ func fillContainers(containers map[*container.Container][]string) error {
 			multiValued.Clear()
 		}
 		for _, v := range vs {
+			// Should check for a valid value
+			if con.Validation != nil {
+				switch x := con.Value.(type) {
+				case values.EnumValued:
+					vc, err := x.Validate(v, con.Validation)
+					if err != nil {
+						return err
+					}
+					v = vc
+				default:
+					panic(fmt.Sprintf("Unhandled validator %v", x))
+				}
+			}
+
 			if err := con.Value.Set(v); err != nil {
 				return err
 			}

--- a/internal/fsm/fsm.go
+++ b/internal/fsm/fsm.go
@@ -137,20 +137,8 @@ func fillContainers(containers map[*container.Container][]string) error {
 			multiValued.Clear()
 		}
 		for _, v := range vs {
-			// Should check for a valid value
-			if con.Validation != nil {
-				switch x := con.Value.(type) {
-				case values.EnumValued:
-					vc, err := x.Validate(v, con.Validation)
-					if err != nil {
-						return err
-					}
-					v = vc
-				default:
-					panic(fmt.Sprintf("Unhandled validator %v", x))
-				}
-			}
-
+			// Validity will be checked in commands.parse, unconditionally set
+			// the value for now.
 			if err := con.Value.Set(v); err != nil {
 				return err
 			}

--- a/internal/values/values.go
+++ b/internal/values/values.go
@@ -20,6 +20,7 @@ type EnumValued interface {
 	flag.Value
 	// Validate makes sure the value passed is valid
 	Validate(string, []container.Validator) (string, error)
+	RealString() string
 }
 
 // MultiValued is an interface ti indicate that a value can hold multiple values
@@ -105,6 +106,11 @@ func (sa *EnumValue) Set(s string) error {
 
 func (sa *EnumValue) String() string {
 	return fmt.Sprintf("%#v", *sa)
+}
+
+// RealString returns the underlying string set in the enum value
+func (sa *EnumValue) RealString() string {
+	return string(*sa)
 }
 
 // IsDefault return true if the string value is empty

--- a/internal/values/values.go
+++ b/internal/values/values.go
@@ -99,28 +99,28 @@ func NewEnum(into *string, v string) *EnumValue {
 }
 
 // Set sets the value from a provided string
-func (sa *EnumValue) Set(s string) error {
-	*sa = EnumValue(s)
+func (ea *EnumValue) Set(s string) error {
+	*ea = EnumValue(s)
 	return nil
 }
 
-func (sa *EnumValue) String() string {
-	return fmt.Sprintf("%#v", *sa)
+func (ea *EnumValue) String() string {
+	return fmt.Sprintf("%#v", *ea)
 }
 
 // RealString returns the underlying string set in the enum value
-func (sa *EnumValue) RealString() string {
-	return string(*sa)
+func (ea *EnumValue) RealString() string {
+	return string(*ea)
 }
 
 // IsDefault return true if the string value is empty
-func (sa *EnumValue) IsDefault() bool {
-	return string(*sa) == ""
+func (ea *EnumValue) IsDefault() bool {
+	return string(*ea) == ""
 }
 
 // Validate validates the specified enum value, returns the wanted value and
 // calls the relevant callback if defined.
-func (sa *EnumValue) Validate(v string, vv []container.Validator) (string, error) {
+func (ea *EnumValue) Validate(v string, vv []container.Validator) (string, error) {
 	for _, x := range vv {
 		if x.User == v {
 			if x.Callback != nil {

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	"github.com/jawher/mow.cli/internal/container"
@@ -26,6 +27,51 @@ type BoolOpt struct {
 }
 
 func (o BoolOpt) value() bool {
+	return o.Value
+}
+
+// EnumValidator allows users to validate enum values
+type EnumValidator struct {
+	// User is the value the user can pass
+	User string
+	// Value is the value assigned to the string for this user value
+	Value string
+	// Help is the help message for this value
+	Help string
+	// Callback is called if this value is set
+	Callback func() error
+}
+
+// ToContainerValidator creates a container validator (shared for all object
+// types) from an object-specific validator
+func (v *EnumValidator) ToContainerValidator(dest *container.Validator) {
+	dest.Type = container.Enum
+	dest.User = v.User
+	dest.Value = v.Value
+	dest.Help = v.Help
+	dest.Callback = v.Callback
+}
+
+// EnumOpt describes a string option
+type EnumOpt struct {
+	// A space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
+	// The one letter names will then be called with a single dash (short option), the others with two (long options).
+	Name string
+	// The option description as will be shown in help messages
+	Desc string
+	// A space separated list of environment variables names to be used to initialize this option
+	EnvVar string
+	// The option's initial value
+	Value string
+	// A boolean to display or not the current value of the option in the help message
+	HideValue bool
+	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
+	SetByUser *bool
+	// Enums contains the enum values
+	Validation []EnumValidator
+}
+
+func (o EnumOpt) value() string {
 	return o.Value
 }
 
@@ -150,6 +196,28 @@ func (c *Cmd) BoolOpt(name string, value bool, desc string) *bool {
 		Name:  name,
 		Value: value,
 		Desc:  desc,
+	})
+}
+
+/*
+EnumOpt defines a enumean option on the command c named `name`, with an initial value of `value` and a description of `desc` which will be used in help messages.
+
+The name is a space separated list of the option names *WITHOUT* the dashes, e.g. `f force` and *NOT* `-f --force`.
+The one letter names will then be called with a single dash (short option), the others with two (long options).
+
+
+The result should be stored in a variable (a pointer to a enum) which will be populated when the app is run and the call arguments get parsed
+*/
+func (c *Cmd) EnumOpt(name string, value string, desc string, validation []EnumValidator) *string {
+	if validation == nil || len(validation) == 0 {
+		panic(fmt.Sprintf("Enums require validation %s %s", name, value))
+	}
+
+	return c.Enum(EnumOpt{
+		Name:       name,
+		Value:      value,
+		Desc:       desc,
+		Validation: validation,
 	})
 }
 

--- a/options.go
+++ b/options.go
@@ -315,6 +315,10 @@ func mkOptStrs(optName string) []string {
 }
 
 func (c *Cmd) mkOpt(opt container.Container) {
+	opt.DefaultValue = opt.Value.String()
+	if dv, ok := opt.Value.(values.DefaultValued); ok {
+		opt.DefaultDisplay = dv.IsDefault()
+	}
 	opt.ValueSetFromEnv = values.SetFromEnv(opt.Value, opt.EnvVar)
 
 	opt.Names = mkOptStrs(opt.Name)

--- a/testdata/help-output.txt
+++ b/testdata/help-output.txt
@@ -1,5 +1,5 @@
 
-Usage: app [-bdsuikqs] BOOL1 [STR1] INT3... COMMAND [arg...]
+Usage: app [-bdesuikqs] BOOL1 [STR1] INT3... COMMAND [arg...]
 
 App Desc
                 
@@ -14,7 +14,7 @@ Arguments:
                   value1: Argument 1 value 1
                   value2: Argument 1 value 2
                   value3: Argument 1 value 3
-  ENUM1         Enum Argument 2 (default "a value") 
+  ENUM2         Enum Argument 2 (default "a value") 
                   value1: Argument 2 value 1
                   value2: Argument 2 value 2
                   value3: Argument 2 value 3

--- a/testdata/help-output.txt
+++ b/testdata/help-output.txt
@@ -10,6 +10,15 @@ Arguments:
   STR1          String Argument 1 (env $STR1)
   STR2          String Argument 2 (env $STR2) (default "a value")
   STR3          String Argument 3 (env $STR3)
+  ENUM1         Enum Argument 1 (env $ENUM1) 
+                  value1: Argument 1 value 1
+                  value2: Argument 1 value 2
+                  value3: Argument 1 value 3
+  ENUM1         Enum Argument 2 (default "a value") 
+                  value1: Argument 2 value 1
+                  value2: Argument 2 value 2
+                  value3: Argument 2 value 3
+  ENUM3         Enum Argument 3 (env $ENUM3)
   INT1          Int Argument 1 (env $INT1) (default 0)
   INT2          Int Argument 2 (env $INT2) (default 1)
   INT3          Int Argument 3 (env $INT3)
@@ -27,6 +36,15 @@ Options:
   -s, --str1    String Option 1 (env $STR1)
       --str2    String Option 2 (default "a value")
   -u            String Option 3 (env $STR3)
+  -e, --enum1   Enum Option 1 (env $ENUM1) 
+                  value1: Option 1 value 1
+                  value2: Option 1 value 2
+                  value3: Option 1 value 3
+      --enum2   Enum Option 2 (default "a value") 
+                  value1: Option 2 value 1
+                  value2: Option 2 value 2
+                  value3: Option 2 value 3
+  -f            Enum Option 3 (env $ENUM3)
   -i, --int1    (env $INT1, $ALIAS_INT1) (default 0)
       --int2    Int Option 2 (env $INT2) (default 1)
   -k            Int Option 3 (env $INT3)


### PR DESCRIPTION
NOTE: This is just an initial pull request to allow for comments, it is not yet fully ready to be merged due to needing more unit test coverage (I just have a few basic tests for the time being), but I figured I'd open it now to make sure you are ok with this approach, if you are I will add the other needed tests in commands_test.go and possibly in internal/ (haven't fully investigated the tests there). This is related to the discussion in issue #5

Basically I really like mow.cli but also need enums and wanted them integrated in the help, so I thought I would take a stab at implementing them, I also added a way to have a callback in the enums, and made the validation hopefully extensible with an eye to supporting users creating StringV and IntV arguments where they could set things like "validate the string as an ipv4 address" or "this int must be between 0 and 1024"

You can kind of see this from the unit tests below, but anyways this is what it looks like in the code: a simple enum, user can set Red/Green/Blue and the value returned is r, g or b
```
		color = app.EnumOpt("c color", "", "The color we want, one of:",
			[]cli.EnumValidator{
				{User: "Red", Value: "r", Help: "The color red"},
				{User: "Green", Value: "g", Help: "The color green"},
				{User: "Blue", Value: "b", Help: "The color blue"},
			})
```

An enum with callbacks, useful for logging for example 

```
	app.EnumOpt("l loglevel", "", "The loglevel to set, one of:",
		[]cli.EnumValidator{
			{User: "error", Callback: func() error {
				zerolog.SetGlobalLevel(zerolog.ErrorLevel)
				return nil
			}, Help: "set to error"},
			{User: "warning", Callback: func() error {
				zerolog.SetGlobalLevel(zerolog.WarnLevel)
				return nil
			}, Help: "set to warning"},
			{User: "debug", Callback: func() error {
				zerolog.SetGlobalLevel(zerolog.DebugLevel)
				return nil
			}, Help: "set to debug"},
		})
```

You can see the help in the golden file, but anyways it's something like this

```
Options:           
  -c, --color      The color we want, one of: 
                     Red: The color red
                     Green: The color green
                     Blue: The color blue
  -l, --loglevel   The loglevel to set, one of: 
                     error: set to error
                     warning: set to warning
                     debug: set to debug
```

Note the pull also has a change to the default value printing in the help, if you try the test case in master you should see the failure, and it seems related to assignments being done in one case but not in the other. If you can think of a cleaner way to fix this it'd be great, from my perspective I think that defaults can be calculated when the initial value is constructed so the approach seems fine, but of course let me know what you think.