### PR TITLE
Update README.md to add LongDesc examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,21 @@ cp.Action = func() {
 }
 ```
 
-If you want you can add support for printing the app version (invoked by ```-v, --version```) like so:
+If you want, you can add support for printing the app version (invoked by ```-v, --version```) like so:
 
 ```go
 cp.Version("v version", "cp 1.2.3")
+```
+
+If you want, you can add a long description for printing via ```--help``` like so:
+
+```go
+cp.LongDesc = `Copy files around
+
+In the first synopsis form, the cp utility copies the contents of the source file to the
+target file.  In the second synopsis form, the contents of each named source file is
+copied to the destination target directory.  The names of the files themselves are not
+changed.  If cp detects an attempt to copy a file to itself, the copy will fail.`
 ```
 
 Finally, in your main func, call Run on the app:
@@ -317,6 +328,19 @@ docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
     }
 })
 ```
+
+If you want, you can add a long description for the command, which is printed via ```--help``` like so:
+
+```go
+cmd.LongDesc = `Run a command in a new container
+
+With the docker run command, an operator can add to or override the
+image defaults set by a developer. And, additionally, operators can
+override nearly all the defaults set by the Docker runtime itself.
+The operator’s ability to override image and Docker runtime defaults
+is why run has more options than any other docker command.`
+```
+
 You can also add sub commands by calling Command on the Cmd struct:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -154,17 +154,6 @@ If you want, you can add support for printing the app version (invoked by ```-v,
 cp.Version("v version", "cp 1.2.3")
 ```
 
-If you want, you can add a long description for printing via ```--help``` like so:
-
-```go
-cp.LongDesc = `Copy files around
-
-In the first synopsis form, the cp utility copies the contents of the source file to the
-target file.  In the second synopsis form, the contents of each named source file is
-copied to the destination target directory.  The names of the files themselves are not
-changed.  If cp detects an attempt to copy a file to itself, the copy will fail.`
-```
-
 Finally, in your main func, call Run on the app:
 
 ```go


### PR DESCRIPTION
While using mow.cli, I did not realize the existence of LongDesc as it was not covered in the documentation. It was only by chance while I was browsing the source, I noticed the feature. This update should make it easier for others to find this useful feature.