### PR TITLE
Unify package doc and github README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ lint:
 vet:
 	go vet
 
+doc:
+	autoreadme -f
+
 fmtcheck:
 	@ export output="$$(gofmt -s -d .)"; \
 		[ -n "$${output}" ] && echo "$${output}" && export status=1; \
@@ -28,6 +31,7 @@ setup:
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/mattn/goveralls
 	go get github.com/modocache/gover
+	go get github.com/divan/autoreadme
 	go get -t -u ./...
 
 .PHONY: test check lint vet fmtcheck ineffassign

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # mow.cli
-
 [![Build Status](https://travis-ci.org/jawher/mow.cli.svg?branch=master)](https://travis-ci.org/jawher/mow.cli)
-[![GoDoc](https://godoc.org/github.com/jawher/mow.cli?status.svg)](https://godoc.org/github.com/jawher/mow.cli)
+[![GoDoc](https://godoc.org/github.com/github.com/jawher/mow.cli?status.svg)](https://godoc.org/github.com/jawher/mow.cli)
 [![Coverage Status](https://coveralls.io/repos/github/jawher/mow.cli/badge.svg?branch=master)](https://coveralls.io/github/jawher/mow.cli?branch=master)
 
-A framework to build command line applications in Go with most of the burden of arguments parsing and validation placed on the framework instead of the developer.
+Package cli provides a framework to build command line applications in Go with most of the burden of arguments parsing and validation placed on the framework instead of the user.
 
-## First app
 
-### A simple app
+## Getting Started
+The following examples demonstrate basic usage the package.
+
+
+### Simple Application
+In this simple application, we mimic the argument parsing of the standard UNIX
+cp command. Our application requires the user to specify one or more source
+files followed by a destination.  An optional recursive flag may be provided.
 
 ```go
 package main
@@ -39,7 +44,81 @@ func main() {
 }
 ```
 
-### An app with multiple commands:
+
+### Multi-Command Application
+In the next example, we create a multi-command application in the same style as
+familiar commands such as git and docker.  We build a fictional utility called
+uman to manage users in a system.  It provides two commands that can be invoked:
+list and get. The list command takes an optional flag to specify all users
+including disabled ones.  The get command requries one argument, the user ID,
+and takes an optional flag to specify a detailed listing.
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/jawher/mow.cli"
+)
+
+func main() {
+    app := cli.App("uman", "User Manager")
+
+    app.Spec = "[-v]"
+
+    var (
+        verbose = app.BoolOpt("v verbose", false, "Verbose debug mode")
+    )
+
+    app.Before = func() {
+        if *verbose {
+            // Here we can enable debug output in our logger for example
+            fmt.Println("Verbose mode enabled")
+        }
+    }
+
+    // Declare our first command, which is invocable with "uman list"
+    app.Command("list", "list the users", func(cmd *cli.Cmd) {
+        // These are the command-specific options and args, nicely scoped
+        // inside a func so they don't pollute the namespace
+        var (
+            all = cmd.BoolOpt("all", false, "List all users, including disabled")
+        )
+
+        // Run this function when the command is invoked
+        cmd.Action = func() {
+            // Inside the action, and only inside, we can safely access the 
+            // values of the options and arguments
+            fmt.Printf("user list (including disabled ones: %v)\n", *all)
+        }
+    })
+
+    // Declare our second command, which is invocable with "uman get"
+    app.Command("get", "get a user details", func(cmd *cli.Cmd) {
+        var (
+            detailed = cmd.BoolOpt("detailed", false, "Disaply detailed info")
+            id       = cmd.StringArg("ID", "", "The user id to display")
+        )
+
+        cmd.Action = func() {
+            fmt.Printf("user %q details (detailed mode: %v)\n", *id, *detailed)
+        }
+    })
+
+    // With the app configured, execute it, passing in the os.Args array
+    app.Run(os.Args)
+}
+```
+
+
+### A Larger Multi-Command Example
+This example shows an alternate way of organizing our code when dealing with a
+larger number of commands and subcommands. This layout emphasizes the command
+structure and defers the details of each command to subsequent functions. Like
+the prior examples, options and arguments are still scoped to their respective
+functions and don't pollute the global namespace.
 
 ```go
 package main
@@ -51,243 +130,304 @@ import (
 	"github.com/jawher/mow.cli"
 )
 
+// Global options available to any of the commands
+var filename *string
+
 func main() {
-	app := cli.App("uman", "User Manager")
+	app := cli.App("vault", "Password Keeper")
 
-	app.Spec = "[-v]"
+	// Define our top-level global options
+	filename = app.StringOpt("f file", os.Getenv("HOME")+"/.safe", "Path to safe")
 
-	var (
-		verbose = app.BoolOpt("v verbose", false, "Verbose debug mode")
-	)
-
-	app.Before = func() {
-		if *verbose {
-			// Here you can enable debug output in your logger for example
-			fmt.Println("Verbose mode enabled")
-		}
-	}
-
-	// Declare a first command, invocable with "uman list"
-	app.Command("list", "list the users", func(cmd *cli.Cmd) {
-		// These are the command specific options and args, nicely scoped inside a func
-		var (
-			all = cmd.BoolOpt("all", false, "Display all users, including disabled ones")
-		)
-
-		// What to run when this command is called
-		cmd.Action = func() {
-			// Inside the action, and only inside, you can safely access the values of the options and arguments
-			fmt.Printf("user list (including disabled ones: %v)\n", *all)
-		}
+	// Define our command structure for usage like this:
+	app.Command("list", "list accounts", cmdList)
+	app.Command("creds", "display account credentials", cmdCreds)
+	app.Command("config", "manage accounts", func(config *cli.Cmd) {
+        config.Command("list", "list accounts", cmdList)
+		config.Command("add", "add an account", cmdAdd)
+		config.Command("remove", "remove an account(s)", cmdRemove)
 	})
 
-	// The second command, invocable with "uman get"
-	app.Command("get", "get a user details", func(cmd *cli.Cmd) {
-		var (
-			detailed = cmd.BoolOpt("detailed", false, "Disaply detailed information")
-			id       = cmd.StringArg("ID", "", "The user id to display")
-		)
-
-		cmd.Action = func() {
-			fmt.Printf("user %q details (detailed mode: %v)\n", *id, *detailed)
-		}
-	})
-
-	// Now that the app is configured, execute it passing in the os.Args array
 	app.Run(os.Args)
+}
+
+// Sample use: vault list OR vault config list
+func cmdList(cmd *cli.Cmd) {
+    cmd.Action = func() {
+        fmt.Printf("list the contents of the safe here")
+	}
+}
+
+// Sample use: vault creds reddit.com
+func cmdCreds(cmd *cli.Cmd) {
+    cmd.Spec = "ACCOUNT"
+	account := cmd.StringArg("ACCOUNT", "", "Name of account")
+	cmd.Action = func() {
+        fmt.Printf("display account info for %s\n", *account)
+	}
+}
+
+// Sample use: vault config add reddit.com -u username -p password
+func cmdAdd(cmd *cli.Cmd) {
+    cmd.Spec = "ACCOUNT [ -u=<username> ] [ -p=<password> ]"
+	var (
+        account  = cmd.StringArg("ACCOUNT", "", "Account name")
+		username = cmd.StringOpt("u username", "admin", "Account username")
+		password = cmd.StringOpt("p password", "admin", "Account password")
+	)
+	cmd.Action = func() {
+        fmt.Printf("Adding account %s:%s@%s", *username, *password, *account)
+	}
+}
+
+// Sample use: vault config remove reddit.com twitter.com
+func cmdRemove(cmd *cli.Cmd) {
+	cmd.Spec = "ACCOUNT..."
+	var (
+		accounts = cmd.StringsArg("ACCOUNT", nil, "Account names to remove")
+	)
+	cmd.Action = func() {
+		fmt.Printf("Deleting accounts: %v", *accounts)
+	}
 }
 ```
 
-## Motivation
 
-|                                                                      | mow.cli | codegangsta/cli | flag |
-|----------------------------------------------------------------------|---------|-----------------|------|
-| Contextual help                                                      | ✓       | ✓               |      |
-| Commands                                                             | ✓       | ✓               |      |
-| Option folding  `-xyz`                                               | ✓       |                 |      |
-| Option Value folding  `-fValue`                                      | ✓       |                 |      |
-| Option exclusion: `--start ❘ --stop`                                 | ✓       |                 |      |
-| Option dependency : `[-a -b]` or `[-a [-b]]`                         | ✓       |                 |      |
-| Arguments validation : `SRC DST`                                     | ✓       |                 |      |
-| Argument optionality : `SRC [DST]`                                   | ✓       |                 |      |
-| Argument repetition : `SRC... DST`                                   | ✓       |                 |      |
-| Option/Argument dependency : `SRC [-f DST]`                          | ✓       |                 |      |
-| Any combination of the above: `[-d ❘ --rm] IMAGE [COMMAND [ARG...]]` | ✓       |                 |      |
+## Comparison to Other Tools
+There are several tools in the Go ecosystem to facilitate the creation of
+command line tools.  The following is a comparison to the built-in flag package
+as well as the popular urfave/cli (formerly known as codegangsta/cli):
 
-In the goland, docopt is another library with rich flags and arguments validation.
-However, it falls short for many use cases:
+|                                                                     | mow.cli | urfave/cli | flag |
+|---------------------------------------------------------------------|---------|------------|------|
+| Contextual help                                                     | ✓       | ✓          |      |
+| Commands                                                            | ✓       | ✓          |      |
+| Option folding `-xyz`                                               | ✓       |            |      |
+| Option value folding `-fValue`                                      | ✓       |            |      |
+| Option exclusion `--start ❘ --stop`                                 | ✓       |            |      |
+| Option dependency `[-a -b]` or `[-a [-b]]`                          | ✓       |            |      |
+| Arguments validation `SRC DST`                                      | ✓       |            |      |
+| Argument optionality `SRC [DST]`                                    | ✓       |            |      |
+| Argument repetition `SRC... DST`                                    | ✓       |            |      |
+| Option/argument dependency `SRC [-f DST]`                           | ✓       |            |      |
+| Any combination of the above `[-d ❘ --rm] IMAGE [COMMAND [ARG...]]` | ✓       |            |      |
 
-|                             | mow.cli | docopt |
-|-----------------------------|---------|--------|
-| Contextual help             | ✓       |        |
-| Backtracking: `SRC... DST`  | ✓       |        |
-| Backtracking: `[SRC] DST`   | ✓       |        |
-| Branching: `(SRC ❘ -f DST)` | ✓       |        |
+Unlike the simple packages above, docopt is another library that supports rich
+set of flag and argument validation. It does, however, fall short for many use
+cases including:
+
+|                            | mow.cli | docopt |
+|----------------------------|---------|--------|
+| Contextual help            | ✓       |        |
+| Backtracking `SRC... DST`  | ✓       |        |
+| Backtracking `[SRC] DST`   | ✓       |        |
+| Branching `(SRC ❘ -f DST)` | ✓       |        |
+
 
 ## Installation
+To install this package, run the following:
 
-To install this library, simply run:
+```shell
+go get github.com/jawher/mow.cli
+```
 
-```
-$ go get github.com/jawher/mow.cli
-```
+# Package Documentation
+
+<!-- Do NOT edit past here. This is replaced by the contents of the package documentation -->
+Package cli provides a framework to build command line applications in Go with
+most of the burden of arguments parsing and validation placed on the framework
+instead of the user.
 
 ## Basics
+To create a new application, initialize an app with cli.App. Specify a name and
+a brief description for the application:
 
-You start by creating an application by passing a name and a description:
-
-```go
+```
 cp := cli.App("cp", "Copy files around")
 ```
 
-To attach the code to execute when the app is launched, assign a function to the Action field:
+To attach code to execute when the app is launched, assign a function to the
+Action field:
 
-```go
+```
 cp.Action = func() {
     fmt.Printf("Hello world\n")
 }
 ```
 
-If you want, you can add support for printing the app version (invoked by ```-v, --version```) like so:
+To assign a version to the application, use Version method and specify the flags
+that will be used to invoke the version command:
 
-```go
+```
 cp.Version("v version", "cp 1.2.3")
 ```
 
-Finally, in your main func, call Run on the app:
+Finally, in the main func, call Run passing in the arguments for parsing:
 
-```go
+```
 cp.Run(os.Args)
 ```
 
 ## Options
+To add one or more command line options (also known as flags), use one of the
+short-form StringOpt, StringsOpt, IntOpt, IntsOpt, or BoolOpt methods on App (or
+Cmd if adding flags to a command or subcommand). For example, to add a boolean
+flag to the cp command that specifies recursive mode, use the following:
 
-To add a (global) option, call one of the (String[s]|Int[s]|Bool)Opt methods on the app:
-
-```go
+```
 recursive := cp.BoolOpt("R recursive", false, "recursively copy the src to dst")
 ```
 
-* The first argument is a space separated list of names (short and long) for the option without the dashes, e.g `"f force"`. While you can specify multiple short or long names, e.g. `"f x force force-push"`, only the first short name and the first long name will be displayed in the help messages
-* The second parameter is the default value for the option
-* The third and last parameter is the option description, as will be shown in the help messages
+The first argument is a space separated list of names for the option without the
+dashes. Generally, both short and long forms are specified, but this is not
+mandatory. Additional names (aliases) can be provide if desired, but these are
+not shown in the auto-generated help. The second argument is the default value
+for the option if it is not supplied by the user. And, the third argument is the
+description to be shown in help messages.
 
-There is also a second set of methods Bool, String, Int, Strings and Ints, which accepts a struct describing the option:
+There is also a second set of methods on App called String, Strings, Int, Ints,
+and Bool, which accept a long-form struct of the type: cli.StringOpt,
+cli.StringsOpt, cli.IntOpt, cli.IntsOpt, cli.BoolOpt. The struct describes the
+option and allows the use of additional features not available in the short-form
+methods described above:
 
-```go
+```
 recursive = cp.Bool(cli.BoolOpt{
-    Name:  "R recursive",
-    Value: false,
-    Desc:  "copy src files recursively",
-    EnvVar: "VAR_RECURSIVE",
-    SetByUser: &recursiveSetByUser,
+    Name:       "R recursive",
+    Value:      false,
+    Desc:       "copy src files recursively",
+    EnvVar:     "VAR_RECURSIVE",
+    SetByUser:  &recursiveSetByUser,
 })
 ```
 
-`EnvVar` accepts a space separated list of environment variables names to be used to initialize the option.
+Two features, EnvVar and SetByUser, can be defined in the long-form struct
+method. EnvVar is a space separated list of environment variables used to
+initialize the option if a value is not provided by the user. When help messages
+are shown, the value of any environment variables will be displayed. SetByUser
+is a pointer to a boolean variable that is set to true if the user specified the
+value on the command line. This can be useful to determine if the value of the
+option was explicitly set by the user or set via the default value.
 
-If `SetByUser` is specified (by passing a pointer to a bool variable), it will be set to `true` if the user explicitly set the option.
+The result of both short- and long-forms is a pointer to a value, which will be
+populated after the command line arguments are parsed. You can only access the
+values stored in the pointers in the Action func, which is invoked after
+argument parsing has been completed. This precludes using the value of one
+option as the default value of another.
 
-The result is a pointer to a value which will be populated after parsing the command line arguments.
-You can access the values in the Action func.
+On the command line, the following syntaxes are supported when specifying
+options.
 
-In the command line, mow.cli accepts the following syntaxes
+Boolean options:
 
-### For boolean options:
+```
+-f         single dash one letter name
+-f=false   single dash one letter name, equal sign followed by true or false
+--force    double dash for longer option names
+-it        single dash for multiple one letter names (option folding), this is equivalent to: -i -t
+```
 
+String and int options:
 
-* `-f` : a single dash for the one letter names
-* `-f=false` : a single dash for the one letter names, equal sign followed by true or false
-* `--force` :  double dash for longer option names
-* `-it` : mow.cli supports option folding, this is equivalent to: -i -t
+```
+-e=value       single dash one letter name, equal sign, followed by the value
+-e value       single dash one letter name, space followed by the value
+-Ivalue        single dash one letter name, immediately followed by the value
+--extra=value  double dash for longer option names, equal sign followed by the value
+--extra value  double dash for longer option names, space followed by the value
+```
 
-### For string, int options:
+Slice options (StringsOpt, IntsOpt) where option is repeated to accumulate
+values in a slice:
 
-
-* `-e=value` : single dash for one letter names, equal sign followed by the value
-* `-e value` : single dash for one letter names, space followed by the value
-* `-Ivalue` : single dash for one letter names immediately followed by the value
-* `--extra=value` : double dash for longer option names, equal sign followed by the value
-* `--extra value` : double dash for longer option names, space followed by the value
-
-### For slice options (StringsOpt, IntsOpt):
-repeat the option to accumulate the values in the resulting slice:
-
-* `-e PATH:/bin -e PATH:/usr/bin` : resulting slice contains `["/bin", "/usr/bin"]`
-* `-ePATH:/bin -ePATH:/usr/bin` : resulting slice contains `["/bin", "/usr/bin"]`
-* `-e=PATH:/bin -e=PATH:/usr/bin` : resulting slice contains `["/bin", "/usr/bin"]`
-* `--env PATH:/bin --env PATH:/usr/bin` : resulting slice contains `["/bin", "/usr/bin"]`
-* `--env=PATH:/bin --env=PATH:/usr/bin` : resulting slice contains `["/bin", "/usr/bin"]`
-
+```
+-e PATH:/bin    -e PATH:/usr/bin     resulting slice contains ["/bin", "/usr/bin"]
+-ePATH:/bin     -ePATH:/usr/bin      resulting slice contains ["/bin", "/usr/bin"]
+-e=PATH:/bin    -e=PATH:/usr/bin     resulting slice contains ["/bin", "/usr/bin"]
+--env PATH:/bin --env PATH:/usr/bin  resulting slice contains ["/bin", "/usr/bin"]
+--env=PATH:/bin --env=PATH:/usr/bin  resulting slice contains ["/bin", "/usr/bin"]
+```
 
 ## Arguments
+To add one or more command line arguments (not prefixed by dashes), use one of
+the short-form StringArg, StringsArg, IntArg, IntsArg, or BoolArg methods on App
+(or Cmd if adding arguments to a command or subcommand). For example, to add two
+string arguments to our cp command, use the following calls:
 
-To accept arguments, you need to explicitly declare them by calling one of the (String[s]|Int[s]|Bool)Arg methods on the app:
-
-```go
+```
 src := cp.StringArg("SRC", "", "the file to copy")
 dst := cp.StringArg("DST", "", "the destination")
 ```
 
-* The first argument is the argument name as will be shown in the help messages
-* The second parameter is the default value for the argument
-* The third parameter is the argument description, as will be shown in the help messages
+The first argument is the name of the argument as displayed in help messages.
+Argument names must be specified as all uppercase.  The second argument is the
+default value for the argument if it is not supplied. And the third, argument is
+the description to be shown in help messages.
 
+There is also a second set of methods on App called String, Strings, Int, Ints,
+and Bool, which accept a long-form struct of the type: cli.StringArg,
+cli.StringsArg, cli.IntArg, cli.IntsArg, cli.BoolArg. The struct describes the
+arguments and allows the use of additional features not available in the
+short-form methods described above:
 
-There is also a second set of methods Bool, String, Int, Strings and Ints, which accepts structs describing the argument:
-
-```go
-src = cp.Strings(cli.StringsArg{
-    Name:  "SRC",
-    Desc:  "The source files to copy",
-    Value: "default value",
-    EnvVar: "VAR1 VAR2",
+```
+src = cp.Strings(StringsArg{
+    Name:      "SRC",
+    Desc:      "The source files to copy",
+    Value:     "default value",
+    EnvVar:    "VAR1 VAR2",
     SetByUser: &srcSetByUser,
 })
 ```
 
-The Value field is where you can set the initial value for the argument.
+Two features, EnvVar and SetByUser, can be defined in the long-form struct
+method. EnvVar is a space separated list of environment variables used to
+initialize the argument if a value is not provided by the user. When help
+messages are shown, the value of any environment variables will be displayed.
+SetByUser is a pointer to a boolean variable that is set to true if the user
+specified the value on the command line. This can be useful to determine if the
+value of the argument was explicitly set by the user or set via the default
+value.
 
-`EnvVar` accepts a space separated list of environment variables names to be used to initialize the argument.
-
-If `SetByUser` is specified (by passing a pointer to a bool variable), it will be set to `true` only if the user explicitly sets the argument.
-
-The result is a pointer to a value that will be populated after parsing the command line arguments.
-You can access the values in the Action func.
-
+The result of both short- and long-forms is a pointer to a value which will be
+populated after the command line arguments are parsed. You can only access the
+values stored in the pointers in the Action func, which is invoked after
+argument parsing has been completed. This precludes using the value of one
+argument as the default value of another.
 
 ## Operators
+The -- operator marks the end of command line options. Everything that follows
+will be treated as an argument, even if starts with a dash.  For example, the
+standard POSIX touch command, which takes a filename as an argument (and
+possibly other options that we'll ignore here), could be defined as:
 
-The `--` operator marks the end of options.
-Everything that follow will be treated as an argument,
-even if starts with a dash.
-
-For example, given the `touch` command which takes a filename as an argument (and possibly other options):
-
-```go
+```
 file := cp.StringArg("FILE", "", "the file to create")
 ```
 
-If we try to create a file named `-f` this way:
+If we try to create a file named "-f" via our touch command:
 
 ```
-touch -f
+$ touch -f
 ```
 
-Would fail, because `-f` will be parsed as an option not as an argument.
-The fix is to prefix the filename with the `--` operator:
+It will fail because the -f will be parsed as an option, not as an argument. The
+fix is to insert -- after all flags have been specified, so the remaining
+arguments are parsed as arguments instead of options as follows:
 
 ```
-touch -- -f
+$ touch -- -f
 ```
+
+This ensures the -f is parsed as an argument instead of a flag named f.
 
 ## Commands
+This package supports nesting of commands and subcommands. Declare a top-level
+command by calling the Command func on the top-level App struct. For example,
+the following creates an application called docker that will have one command
+called run:
 
-mow.cli supports nesting commands and sub commands.
-Declare a top level command by calling the Command func on the app struct, and a sub command by calling
-the Command func on the command struct:
-
-```go
+```
 docker := cli.App("docker", "A self-sufficient runtime for linux containers")
 
 docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
@@ -295,32 +435,41 @@ docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
 })
 ```
 
-* The first argument is the command name, as will be shown in the help messages and as will need to be input by the user in the command line to call the command
-* The second argument is the command description as will be shown in the help messages
-* The third argument is a CmdInitializer, a function that receives a pointer to a Cmd struct representing the command.
-In this function, you can add options and arguments by calling the same methods as you would with an app struct (BoolOpt, StringArg, ...).
-You would also assign a function to the Action field of the Cmd struct for it to be executed when the command is invoked.
+The first argument is the name of the command the user will specify on the
+command line to invoke this command.  The second argument is the description of
+the command shown in help messages.  And, the last argument is a CmdInitializer,
+which is a function that receives a pointer to a Cmd struct representing the
+command.
 
-```go
+Within this function, define the options and arguments for the command by
+calling the same methods as you would with top-level App struct (BoolOpt,
+StringArg, ...).  To execute code when the command is invoked, assign a function
+to the Action field of the Cmd struct. Within that function, you can safely
+refer to the options and arguments as command line parsing will be completed at
+the time the function is invoked:
+
+```
 docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
     var (
-        detached = cmd.BoolOpt("d detach", false, "Detached mode: run the container in the background and print the new container ID")
-        memory   = cmd.StringOpt("m memory", "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)")
-        image    = cmd.StringArg("IMAGE", "", "")
+        detached = cmd.BoolOpt("d detach", false, "Run container in background")
+        memory   = cmd.StringOpt("m memory", "", "Set memory limit")
+        image    = cmd.StringArg("IMAGE", "", "The image to run")
     )
-    
+
     cmd.Action = func() {
         if *detached {
-            //do something
+            // do something
         }
         runContainer(*image, *detached, *memory)
     }
 })
 ```
 
-If you want, you can add a long description for the command, which is printed via ```--help``` like so:
+Optionally, to provide a more extensive description of the command, assign a
+string to LongDesc, which is displayed when a user invokes --help. A LongDesc
+can be provided for Cmds as well as the top-level App:
 
-```go
+```
 cmd.LongDesc = `Run a command in a new container
 
 With the docker run command, an operator can add to or override the
@@ -330,240 +479,158 @@ The operator’s ability to override image and Docker runtime defaults
 is why run has more options than any other docker command.`
 ```
 
-You can also add sub commands by calling Command on the Cmd struct:
+Subcommands can be added by calling Command on the Cmd struct. They can by
+defined to any depth if needed:
 
-```go
-bzk.Command("job", "actions on jobs", func(cmd *cli.Cmd) {
-    cmd.Command("list", "list jobs", listJobs)
-    cmd.Command("start", "start a new job", startJob)
-    cmd.Command("log", "show a job log", nil)
-})
 ```
-
-When you just want to set Action to cmd, you can use ActionCommand function for this:
-
-```go
-app.Command("list", "list all configs", cli.ActionCommand(list))
-```
-
-is the same as:
-
-```go
-app.Command("list", "list all configs", func(cmd *cli.Cmd)) {
-    cmd.Action = func() {
-      list()
-    }
-}
-```
-
-This could go on to any depth if need be.
-
-mow.cli also supports command aliases. For example:
-
-```go
-app.Command("start run r", "start doing things", cli.ActionCommand(start))
-```
-
-will alias `start`, `run`, and `r` to the same action. Aliases also work for
-subcommands:
-
-```go
-app.Command("job j", "actions on jobs", func(cmd *cli.Cmd) {
-    cmd.Command("list ls", "list jobs", func(cmd *cli.Cmd) {
-        cmd.Action = func() {
-            list()
-        }
+docker.Command("job", "actions on jobs", func(job *cli.Cmd) {
+    job.Command("list", "list jobs", listJobs)
+    job.Command("start", "start a new job", startJob)
+    job.Command("log", "log commands", func(log *cli.Cmd) {
+        log.Command("show", "show logs", showLog)
+        log.Command("clear", "clear logs", clearLog)
     })
 })
 ```
 
-which then allows you to invoke the subcommand as `app job list`, `app job ls`,
-`app j ls`, or `app j list`.
+Command and subcommand aliases are also supported. To define one or more
+aliases, specify a space-separated list of strings to the first argument of
+Command:
 
+```
+job.Command("start run r", "start a new job", startJob)
+```
 
-As a side-note: it may seem a bit weird the way mow.cli uses a function to initialize a command instead of just returning the command struct.
+With the command structure defined above, users can invoke the app in a variety
+of ways:
 
-The motivation behind this choice is scoping: as with the standard flag package, adding an option or an argument returns a pointer to a value which will be populated when the app is run.
+```
+$ docker job list
+$ docker job start
+$ docker job run   # using the alias we defined
+$ docker job r     # using the alias we defined
+$ docker job log show
+$ docker job log clear
+```
 
-Since you'll want to store these pointers in variables, and to avoid having dozens of them in the same scope (the main func for example or as global variables),
-mow.cli's API was specifically tailored to take a func parameter (called CmdInitializer) which accepts the command struct.
+As a convenience, to assign an Action to a func with no arguments, use
+ActionCommand when defining the Command. For example, the following two
+statements are equivalent:
 
-This way, the command specific variables scope is limited to this function.
+```
+app.Command("list", "list all configs", cli.ActionCommand(list))
 
-## Custom types
-
-Out of the box, mow.cli supports the following types for options and arguments:
-
-* bool
-* string
-* int
-* strings (slice of strings)
-* ints (slice of ints)
-
-You can however extend mow.cli to handle other types, e.g. `time.Duration`, `float64`, or even your own struct types for example.
-
-To do so, you'll need to:
-
-* implement the `flag.Value` interface for the custom type
-* declare the option or the flag using `VarOpt`, `VarArg` for the short hands, and `Var` for the full form.
-
-Here's an example:
-
-```go
-// Declare your type
-type Duration time.Duration
-
-// Make it implement flag.Value
-func (d *Duration) Set(v string) error {
-	parsed, err := time.ParseDuration(v)
-	if err != nil {
-		return err
-	}
-	*d = Duration(parsed)
-	return nil
-}
-
-func (d *Duration) String() string {
-	duration := time.Duration(*d)
-	return duration.String()
-}
-
-func main() {
-    duration := Duration(0)
-
-	app := App("var", "")
-
-	app.VarArg("DURATION", &duration, "")
-
-	app.Run([]string{"cp", "1h31m42s"})
+// Exactly the same as above, just more verbose
+app.Command("list", "list all configs", func(cmd *cli.Cmd)) {
+    cmd.Action = func() {
+        list()
+    }
 }
 ```
 
-### Boolean custom types
+Please note that options, arguments, specs, and long descriptions cannot be
+provided when using ActionCommand. This is intended for very simple command
+invocations that take no arguments.
 
-To make your custom type behave as a boolean option, i.e. doesn't take a value, it has to implement a `IsBoolFlag` method that returns true:
-
-```go
-type BoolLike int
-
-
-func (d *BoolLike) IsBoolFlag() bool {
-	return true
-}
-```
-
-### Multi-valued custom type
-
-To make your custom type behave as a multi-valued option or argument, i.e. takes multiple values,
-it has to implement a `Clear` method which will be called whenever the value list needs to be cleared,
-e.g. when the value was initially populated from an environment variable, and then explicitly set from the CLI:
-
-```go
-type Durations []time.Duration
-
-// Make it implement flag.Value 
-func (d *Durations) Set(v string) error {
-	parsed, err := time.ParseDuration(v)
-	if err != nil {
-		return err
-	}
-	*d = append(*d, Duration(parsed))
-	return nil
-}
-
-func (d *Durations) String() string {
-	return fmt.Sprintf("%v", *d)
-}
-
-
-// Make it multi-valued
-func (d *Durations) Clear() {
-	*d = []Duration{}
-}
-```
-
-### Hide default value of custom type
-
-If your custom type implements a `IsDefault` method (returning a boolean), the help message generation will make use of it to decide whether or not to display the default value.
-
-```go
-type Action string
-
-// Make it implement flag.Value
-:
-:
-
-// Make it multi-valued
-func (a *Action) IsDefault() bool {
-	return (*a) == "nop"
-}
-```
+Finally, as a side-note, it may seem a bit weird that this package uses a
+function to initialize a command instead of simply returning a command struct.
+The motivation behind this API decision is scoping: as with the standard flag
+package, adding an option or an argument returns a pointer to a value which will
+be populated when the app is run.  Since you'll want to store these pointers in
+variables, and to avoid having dozens of them in the same scope (the main func
+for example or as global variables), this API was specifically tailored to take
+a func parameter (called CmdInitializer), which accepts the command struct. With
+this design, the command's specific variables are limited in scope to this
+function.
 
 ## Interceptors
+Interceptors, or hooks, can be defined to be executed before and after a command
+or when any of its subcommands are executed.  For example, the following app
+defines multiple commands as well as a global flag which toggles verbosity:
 
-It is possible to define snippets of code to be executed before and after a command or any of its sub commands is executed.
-
-For example, given an app with multiple commands but with a global flag which toggles a verbose mode:
-
-```go
+```
 app := cli.App("app", "bla bla")
-
-verbose := app.Bool(cli.BoolOpt{
-	Name:  "verbose",
-	Value: false,
-	Desc:  "Enable debug logs",
-})
+verbose := app.BoolOpt("verbose v", false, "Enable debug logs")
 
 app.Command("command1", "...", func(cmd *cli.Cmd) {
-
+    if (*verbose) {
+        logrus.SetLevel(logrus.DebugLevel)
+    }
 })
 
 app.Command("command2", "...", func(cmd *cli.Cmd) {
-
+    if (*verbose) {
+        logrus.SetLevel(logrus.DebugLevel)
+    }
 })
 ```
 
-Instead of repeating yourself by checking if the verbose flag is set or not, and setting the debug level in every command (and its sub-commands),
-a before interceptor can be set on the `app` instead:
+Instead of duplicating the check for the verbose flag and setting the debug
+level in every command (and its sub-commands), a Before interceptor can be set
+on the top-level App instead:
 
-```go
+```
 app.Before = func() {
-	if (*verbose) {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
+    if (*verbose) {
+        logrus.SetLevel(logrus.DebugLevel)
+    }
 }
 ```
 
-Whenever a valid command is called by the user, all the before interceptors defined on the app and the intermediate commands
-will be called, in order from the root to the leaf.
+Whenever a valid command is called by the user, all the Before interceptors
+defined on the app and the intermediate commands will be called, in order from
+the root to the leaf.
 
-Similarly, if you need to execute a code snippet after a command has been called, e.g. to cleanup resources allocated in before interceptors,
-simply set the `After` field of the app struct or any other command.
-`After` interceptors will be called, in order from the leaf up to the root (the opposite order of the `Before` interceptors).
+Similarly, to execute a hook after a command has been called, e.g. to cleanup
+resources allocated in Before interceptors, simply set the After field of the
+App struct or any other Command. After interceptors will be called, in order,
+from the leaf up to the root (the opposite order of the Before interceptors).
 
-Here's a diagram which shows in when and in which order multiple `Before` and `After` interceptors get executed:
+The following diagram shows when and in which order multiple Before and After
+interceptors are executed:
 
-![flow](http://i.imgur.com/oUEa8Sh.png)
+```
++------------+    success    +------------+   success   +----------------+     success
+| app.Before +---------------> cmd.Before +-------------> sub_cmd.Before +---------+
++------------+               +-+----------+             +--+-------------+         |
+                               |                           |                     +-v-------+
+                 error         |           error           |                     | sub_cmd |
+       +-----------------------+   +-----------------------+                     | Action  |
+       |                           |                                             +-+-------+
++------v-----+               +-----v------+             +----------------+         |
+| app.After  <---------------+ cmd.After  <-------------+  sub_cmd.After <---------+
++------------+    always     +------------+    always   +----------------+      always
+```
 
-## Spec
+## Exiting
+To exit the application, use cli.Exit function, which accepts an exit code and
+exits the app with the provided code.  It is important to use cli.Exit instead
+of os.Exit as the former ensures that all of the After interceptors are executed
+before exiting.
 
-An app or command's call syntax can be customized using spec strings.
-This can be useful to indicate that an argument is optional for example, or that 2 options are mutually exclusive.
+```
+cli.Exit(1)
+```
 
-You can set a spec string on:
+## Spec Strings
+An App or Command's invocation syntax can be customized using spec strings. This
+can be useful to indicate that an argument is optional or that two options are
+mutually exclusive.  The spec string is one of the key differentiators between
+this package and other CLI packages as it allows the developer to express usage
+in a simple, familiar, yet concise grammar.
 
-* The app: to configure the syntax for global options and arguments
-* A command: to configure the syntax for that command's options and arguments
+To define option and argument usage for the top-level App, assign a spec string
+to the App's Spec field:
 
-In both cases, a spec string is assigned to the Spec field:
-
-```go
+```
 cp := cli.App("cp", "Copy files around")
 cp.Spec = "[-R [-H | -L | -P]]"
 ```
 
-And:
-```go
+Likewise, to define option and argument usage for a command or subcommand,
+assign a spec string to the Command's Spec field:
+
+```
 docker := cli.App("docker", "A self-sufficient runtime for linux containers")
 docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
     cmd.Spec = "[-d|--rm] IMAGE [COMMAND [ARG...]]"
@@ -572,156 +639,164 @@ docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
 }
 ```
 
-The spec syntax is mostly based on the conventions used in POSIX command line apps help messages and man pages:
+The spec syntax is mostly based on the conventions used in POSIX command line
+applications (help messages and man pages). This syntax is described in full
+below. If a user invokes the app or command with the incorrect syntax, the app
+terminates with a help message showing the proper invocation. The remainder of
+this section describes the many features and capabilities of the spec string
+grammar.
 
-### Options
+Options can use both short and long option names in spec strings.  In the
+example below, the option is mandatory and must be provided.  Any options
+referenced in a spec string MUST be explicitly declared, otherwise this package
+will panic. I.e. for each item in the spec string, a corresponding *Opt or *Arg
+is required:
 
-You can use both short and long option names in spec strings:
-```go
-x.Spec="-f"
 ```
-And:
-```go
-x.Spec="--force"
+x.Spec = "-f"  // or x.Spec = "--force"
+forceFlag := x.BoolOpt("f force", ...)
 ```
 
-In both cases, we required that the f or force flag be set
+Arguments are specified with all-uppercased words.  In the example below, both
+SRC and DST must be provided by the user (two arguments).  Like options, any
+argument referenced in a spec string MUST be explicitly declared, otherwise this
+package will panic:
 
-Any option you reference in a spec string MUST be explicitly declared, otherwise mow.cli will panic:
-```go
-x.BoolOpt("f force", ...)
 ```
-### Arguments
-
-Arguments are all-uppercased words:
-```go
 x.Spec="SRC DST"
+src := x.StringArg("SRC", ...)
+dst := x.StringArg("DST", ...)
 ```
 
-This spec string will force the user to pass exactly 2 arguments, SRC and DST
+With the exception of options, the order of the elements in a spec string is
+respected and enforced when command line arguments are parsed.  In the example
+below, consecutive options (-f and -g) are parsed regardless of the order they
+are specified (both "-f=5 -g=6" and "-g=6 -f=5" are valid).  Order between
+options and arguments is significant (-f and -g must appear before the SRC
+argument). The same holds true for arguments, where SRC must appear before DST:
 
-Any argument you reference in a spec string MUST be explicitly declared, otherwise mow.cli will panic:
-
-```go
-x.StringArg("SRC", ...)
-x.StringArg("DST", ...)
 ```
-
-### Ordering
-
-Except for options, The order of the elements in a spec string is respected and enforced when parsing the command line arguments:
-
-```go
 x.Spec = "-f -g SRC -h DST"
+var (
+    factor = x.IntOpt("f", 1, "Fun factor (1-5)")
+    games  = x.IntOpt("g", 1, "# of games")
+    health = x.IntOpt("h", 1, "# of hosts")
+    src    = x.StringArg("SRC", ...)
+    dst    = x.StringArg("DST", ...)
+)
 ```
 
-Consecutive options (`-f` and `-g` for example) get parsed regardless of the order they are specified in (both `-f=5 -g=6` and `-g=6 -f=5` are valid).
+Optionality of options and arguments is specified in a spec string by enclosing
+the item in square brackets []. If the user does not provide an optional value,
+the app will use the default value specified when the argument was defined. In
+the example below, if -x is not provided, heapSize will default to 1024:
 
-Order between options and arguments is significant (`-f` and `-g` must appear before the `SRC` argument).
-
-Same goes for arguments, where `SRC` must appear before `DST`.
-
-### Optionality
-
-You can mark items as optional in a spec string by enclosing them in square brackets :`[...]`
-```go
+```
 x.Spec = "[-x]"
+heapSize := x.IntOpt("x", 1024, "Heap size in MB")
 ```
 
-### Choice
+Choice between two or more items is specified in a spec string by separating
+each choice with the | operator. Choices are mutually exclusive. In the examples
+below, only a single choice can be provided by the user otherwise the app will
+terminate displaying a help message on proper usage:
 
-You can use the `|` operator to indicate a choice between two or more items
-```go
+```
 x.Spec = "--rm | --daemon"
 x.Spec = "-H | -L | -P"
 x.Spec = "-t | DST"
 ```
 
-### Repetition
+Repetition of options and arguments is specified in a spec string with the ...
+postfix operator to mark an item as repeatable. Both options and arguments
+support repitition. In the example below, users may invoke the command with
+multiple -e options and multiple SRC arguments:
 
-You can use the `...` postfix operator to mark an element as repeatable:
+```
+x.Spec = "-e... SRC..."
 
-```go
-x.Spec="SRC..."
-x.Spec="-e..."
+// Allows parsing of the following shell command:
+//   $ app -eeeee file1 file2
+//   $ app -e -e -e -e file1 file2
 ```
 
-### Grouping
+Grouping of options and arguments is specified in a spec string with
+parenthesis.  When combined with the choice | and repetition ... operators,
+complex syntaxes can be created. The parenthesis in the example below indicate a
+repeatable sequence of a -e option followed by an argument, and that is mutually
+exclusive to a choice between -x and -y options.
 
-You can group items using parenthesis. This is useful in combination with the choice and repetition operators (`|` and `...`):
-
-```go
+```
 x.Spec = "(-e COMMAND)... | (-x|-y)"
+
+// Allows parsing of the following shell command:
+//   $ app -e show -e add
+//   $ app -y
+// But not the following:
+//   $ app -e show -x
 ```
 
-The parenthesis in the example above serve to mark that it is the sequence of a -e flag followed by an argument that is repeatable, and that
-all that is mutually exclusive to a choice between -x and -y options.
+Option groups, or option folding, are a shorthand method to declaring a choice
+between multiple options.  I.e. any combination of the listed options in any
+order with at least one option selected. The following two statements are
+equivalent:
 
-### Option group
-
-This is a shortcut to declare a choice between multiple options:
-```go
+```
 x.Spec = "-abcd"
-```
-
-Is equivalent to:
-
-```go
 x.Spec = "(-a | -b | -c | -d)..."
 ```
 
-I.e. any combination of the listed options in any order, with at least one option.
+Option groups are typically used in conjunction with optionality [] operators.
+I.e. any combination of the listed options in any order or none at all. The
+following two statements are equivalent:
 
-### All options
-
-Another shortcut:
-
-```go
-x.Spec = "[OPTIONS]"
 ```
-
-This is a special syntax (the square brackets are not for marking an optional item, and the uppercased word is not for an argument).
-This is equivalent to a repeatable choice between all the available options.
-For example, if an app or a command declares 4 options a, b, c and d, `[OPTIONS]` is equivalent to:
-
-```go
+x.Spec = "[-abcd]"
 x.Spec = "[-a | -b | -c | -d]..."
 ```
 
-### Inline option values
+All of the options can be specified using a special syntax: [OPTIONS]. This is a
+special token in the spec string (not optionality and not an argument called
+OPTIONS). It is equivalent to an optional repeatable choice between all the
+available options. For example, if an app or a command declares 4 options a, b,
+c and d, then the following two statements are equivalent:
 
-You can use the `=<some-text>` notation right after an option (long or short form) to give an inline description or value.
+```
+x.Spec = "[OPTIONS]"
+x.Spec = "[-a | -b | -c | -d]..."
+```
 
-An example:
+Inline option values are specified in the spec string with the =<some-text>
+notation immediately following an option (long or short form) to provide users
+with an inline description or value. The actual inline values are ignored by the
+spec parser as they exist only to provide a contextual hint to the user. In the
+example below, "absolute-path" and "in seconds" are ignored by the parser:
 
-```go
+```
 x.Spec = "[ -a=<absolute-path> | --timeout=<in seconds> ] ARG"
 ```
 
-The inline values are ignored by the spec parser and are just there for the final user as a contextual hint.
+The -- operator can be used to automatically treat everything following it as
+arguments.  In other words, placing a -- in the spec string automatically
+inserts a -- in the same position in the program call arguments. This lets you
+write programs such as the POSIX time utility for example:
 
-### Operators
+```
+x.Spec = "-lp [-- CMD [ARG...]]"
 
-The `--` operator can be used in a spec string to automatically treat everything following it as an options.
-
-In other words, placing a `--` in the spec string automatically inserts a `--` in the same position in the program call arguments.
-
-This lets you write programs like the `time` utility for example:
-
-```go
-x.Spec = "time -lp [-- CMD [ARG...]]"
+// Allows parsing of the following shell command:
+//   $ app -p ps -aux
 ```
 
-## Grammar
-
-Here's the (simplified) EBNF grammar for the Specs language:
+## Spec Grammar
+Below is the full EBNF grammar for the Specs language:
 
 ```
 spec         -> sequence
 sequence     -> choice*
 req_sequence -> choice+
 choice       -> atom ('|' atom)*
-atom         -> (shortOpt | longOpt | optSeq | allOpts | group | optional) rep? | optEnd
+atom         -> (shortOpt | longOpt | optSeq | allOpts | group | optional) rep?
 shortOp      -> '-' [A-Za-z]
 longOpt      -> '--' [A-Za-z][A-Za-z0-9]*
 optSeq       -> '-' [A-Za-z]+
@@ -729,57 +804,159 @@ allOpts      -> '[OPTIONS]'
 group        -> '(' req_sequence ')'
 optional     -> '[' req_sequence ']'
 rep          -> '...'
-optEnd       -> '--'
 ```
-And that's it for the spec language.
-You can combine these few building blocks in any way you want (while respecting the grammar above) to construct sophisticated validation constraints
-(don't go too wild though).
 
-Behind the scenes, mow.cli parses the spec string and constructs a finite state machine to be used to parse the command line arguments.
-mow.cli also handles backtracking, and so it can handle tricky cases, or what I like to call "the cp test"
+By combining a few of these building blocks together (while respecting the
+grammar above), powerful and sophisticated validation constraints can be created
+in a simple and concise manner without having to define in code. This is one of
+the key differentiators between this package and other CLI packages. Validation
+of usage is handled entirely by the package through the spec string.
+
+Behind the scenes, this package parses the spec string and constructs a finite
+state machine used to parse the command line arguments. It also handles
+backtracking, which allows it to handle tricky cases, or what I like to call
+"the cp test":
+
 ```
 cp SRC... DST
 ```
 
-Without backtracking, this deceptively simple spec string cannot be parsed correctly.
-For instance, docopt can't handle this case, whereas mow.cli does.
+Without backtracking, this deceptively simple spec string cannot be parsed
+correctly. For instance, docopt can't handle this case, whereas this package
+does.
 
-## Default spec
+## Default Spec
+By default an auto-generated spec string is created for the app and every
+command unless a spec string has been set by the user.  This can simplify use of
+the package even further for simple syntaxes.
 
-By default, and unless a spec string is set by the user, mow.cli auto-generates one for the app and every command using this logic:
+The following logic is used to create an auto-generated spec string: 1) start
+with an empty spec string, 2) if at least one option was declared, append
+"[OPTIONS]" to the spec string, and 3) for each declared argument, append it, in
+the order of declaration, to the spec string. For example, given this command
+declaration:
 
-* Start with an empty spec string
-* If at least one option was declared, append `[OPTIONS]` to the spec string
-* For every declared argument, append it, in the order of declaration, to the spec string
-
-For example, given this command declaration:
-
-```go
+```
 docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
     var (
-        detached = cmd.BoolOpt("d detach", false, "Detached mode: run the container in the background and print the new container ID", nil)
-        memory   = cmd.StringOpt("m memory", "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)", nil)
-        image    = cmd.StringArg("IMAGE", "", "", nil)
-        args     = cmd.StringsArg("ARG", "", "", nil)
+        detached = cmd.BoolOpt("d detach", false, "Run container in background")
+        memory   = cmd.StringOpt("m memory", "", "Set memory limit")
+        image    = cmd.StringArg("IMAGE", "", "The image to run")
+        args     = cmd.StringsArg("ARG", nil, "Arguments")
     )
 })
 ```
 
-The auto-generated spec string would be:
-```go
+The auto-generated spec string, which should suffice for simple cases, would be:
+
+```
 [OPTIONS] IMAGE ARG
 ```
 
-Which should suffice for simple cases. If not, the spec string has to be set explicitly.
+If additional constraints are required, the spec string must be set explicitly
+using the grammar documented above.
 
-## Exiting
+## Custom Types
+By default, the following types are supported for options and arguments: bool,
+string, int, strings (slice of strings), and ints (slice of ints).  You can,
+however, extend this package to handle other types, e.g. time.Duration, float64,
+or even your own struct types.
 
-`mow.cli` provides the `Exit` function which accepts an exit code and exits the app with the provided code.
+To define your own custom type, you must implement the flag.Value interface for
+your custom type, and then declare the option or argument using VarOpt or VarArg
+respectively if using the short-form methods. If using the long-form struct,
+then use Var instead.
 
-You are highly encouraged to call `cli.Exit` instead of `os.Exit` for the `After` interceptors to be executed.
+The following example defines a custom type for a duration. It defines a
+duration argument that users will be able to invoke with strings in the form of
+"1h31m42s":
+
+```
+// Declare your type
+type Duration time.Duration
+
+// Make it implement flag.Value
+func (d *Duration) Set(v string) error {
+    parsed, err := time.ParseDuration(v)
+    if err != nil {
+        return err
+    }
+    *d = Duration(parsed)
+    return nil
+}
+
+func (d *Duration) String() string {
+    duration := time.Duration(*d)
+    return duration.String()
+}
+
+func main() {
+    duration := Duration(0)
+    app := App("var", "")
+    app.VarArg("DURATION", &duration, "")
+    app.Run([]string{"cp", "1h31m42s"})
+}
+```
+
+To make a custom type to behave as a boolean option, i.e. doesn't take a value,
+it must implement the IsBoolFlag method that returns true:
+
+```
+type BoolLike int
+
+func (d *BoolLike) IsBoolFlag() bool {
+    return true
+}
+```
+
+To make a custom type behave as a multi-valued option or argument, i.e. takes
+multiple values, it must implement the Clear method, which is called whenever
+the values list needs to be cleared, e.g. when the value was initially populated
+from an environment variable, and then explicitly set from the CLI:
+
+```
+type Durations []time.Duration
+
+// Make it implement flag.Value
+func (d *Durations) Set(v string) error {
+    parsed, err := time.ParseDuration(v)
+    if err != nil {
+        return err
+    }
+    *d = append(*d, Duration(parsed))
+    return nil
+}
+
+func (d *Durations) String() string {
+    return fmt.Sprintf("%v", *d)
+}
+
+// Make it multi-valued
+func (d *Durations) Clear() {
+    *d = []Duration{}
+}
+```
+
+To hide the default value of a custom type, it must implement the IsDefault
+method that returns a boolean. The help message generator will use the return
+value to decide whether or not to display the default value to users:
+
+```
+type Action string
+
+func (a *Action) IsDefault() bool {
+    return (*a) == "nop"
+}
+```
+
+
+
+
 
 ## License
-
 This work is published under the MIT license.
 
 Please see the `LICENSE` file for details.
+
+* * *
+Automatically generated by [autoreadme](https://github.com/jimmyfrasche/autoreadme) on 2018.04.01

--- a/README.md.template
+++ b/README.md.template
@@ -1,0 +1,250 @@
+# mow.cli
+[![Build Status](https://travis-ci.org/{{.RepoPath}}.svg?branch=master)](https://travis-ci.org/{{.RepoPath}})
+[![GoDoc](https://godoc.org/github.com/{{.Import}}?status.svg)](https://godoc.org/{{.Import}})
+[![Coverage Status](https://coveralls.io/repos/github/{{.RepoPath}}/badge.svg?branch=master)](https://coveralls.io/github/{{.RepoPath}}?branch=master)
+
+{{.Synopsis}}
+
+
+## Getting Started
+The following examples demonstrate basic usage the package.
+
+
+### Simple Application
+In this simple application, we mimic the argument parsing of the standard UNIX
+cp command. Our application requires the user to specify one or more source
+files followed by a destination.  An optional recursive flag may be provided.
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/jawher/mow.cli"
+)
+
+func main() {
+    app := cli.App("cp", "Copy files around")
+
+    app.Spec = "[-r] SRC... DST"
+
+    var (
+        recursive = app.BoolOpt("r recursive", false, "Copy files recursively")
+        src       = app.StringsArg("SRC", nil, "Source files to copy")
+        dst       = app.StringArg("DST", "", "Destination where to copy files to")
+    )
+
+    app.Action = func() {
+        fmt.Printf("Copying %v to %s [recursively: %v]\n", *src, *dst, *recursive)
+    }
+
+    app.Run(os.Args)
+}
+```
+
+
+### Multi-Command Application
+In the next example, we create a multi-command application in the same style as
+familiar commands such as git and docker.  We build a fictional utility called
+uman to manage users in a system.  It provides two commands that can be invoked:
+list and get. The list command takes an optional flag to specify all users
+including disabled ones.  The get command requries one argument, the user ID,
+and takes an optional flag to specify a detailed listing.
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/jawher/mow.cli"
+)
+
+func main() {
+    app := cli.App("uman", "User Manager")
+
+    app.Spec = "[-v]"
+
+    var (
+        verbose = app.BoolOpt("v verbose", false, "Verbose debug mode")
+    )
+
+    app.Before = func() {
+        if *verbose {
+            // Here we can enable debug output in our logger for example
+            fmt.Println("Verbose mode enabled")
+        }
+    }
+
+    // Declare our first command, which is invocable with "uman list"
+    app.Command("list", "list the users", func(cmd *cli.Cmd) {
+        // These are the command-specific options and args, nicely scoped
+        // inside a func so they don't pollute the namespace
+        var (
+            all = cmd.BoolOpt("all", false, "List all users, including disabled")
+        )
+
+        // Run this function when the command is invoked
+        cmd.Action = func() {
+            // Inside the action, and only inside, we can safely access the 
+            // values of the options and arguments
+            fmt.Printf("user list (including disabled ones: %v)\n", *all)
+        }
+    })
+
+    // Declare our second command, which is invocable with "uman get"
+    app.Command("get", "get a user details", func(cmd *cli.Cmd) {
+        var (
+            detailed = cmd.BoolOpt("detailed", false, "Disaply detailed info")
+            id       = cmd.StringArg("ID", "", "The user id to display")
+        )
+
+        cmd.Action = func() {
+            fmt.Printf("user %q details (detailed mode: %v)\n", *id, *detailed)
+        }
+    })
+
+    // With the app configured, execute it, passing in the os.Args array
+    app.Run(os.Args)
+}
+```
+
+
+### A Larger Multi-Command Example
+This example shows an alternate way of organizing our code when dealing with a
+larger number of commands and subcommands. This layout emphasizes the command
+structure and defers the details of each command to subsequent functions. Like
+the prior examples, options and arguments are still scoped to their respective
+functions and don't pollute the global namespace.
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jawher/mow.cli"
+)
+
+// Global options available to any of the commands
+var filename *string
+
+func main() {
+	app := cli.App("vault", "Password Keeper")
+
+	// Define our top-level global options
+	filename = app.StringOpt("f file", os.Getenv("HOME")+"/.safe", "Path to safe")
+
+	// Define our command structure for usage like this:
+	app.Command("list", "list accounts", cmdList)
+	app.Command("creds", "display account credentials", cmdCreds)
+	app.Command("config", "manage accounts", func(config *cli.Cmd) {
+        config.Command("list", "list accounts", cmdList)
+		config.Command("add", "add an account", cmdAdd)
+		config.Command("remove", "remove an account(s)", cmdRemove)
+	})
+
+	app.Run(os.Args)
+}
+
+// Sample use: vault list OR vault config list
+func cmdList(cmd *cli.Cmd) {
+    cmd.Action = func() {
+        fmt.Printf("list the contents of the safe here")
+	}
+}
+
+// Sample use: vault creds reddit.com
+func cmdCreds(cmd *cli.Cmd) {
+    cmd.Spec = "ACCOUNT"
+	account := cmd.StringArg("ACCOUNT", "", "Name of account")
+	cmd.Action = func() {
+        fmt.Printf("display account info for %s\n", *account)
+	}
+}
+
+// Sample use: vault config add reddit.com -u username -p password
+func cmdAdd(cmd *cli.Cmd) {
+    cmd.Spec = "ACCOUNT [ -u=<username> ] [ -p=<password> ]"
+	var (
+        account  = cmd.StringArg("ACCOUNT", "", "Account name")
+		username = cmd.StringOpt("u username", "admin", "Account username")
+		password = cmd.StringOpt("p password", "admin", "Account password")
+	)
+	cmd.Action = func() {
+        fmt.Printf("Adding account %s:%s@%s", *username, *password, *account)
+	}
+}
+
+// Sample use: vault config remove reddit.com twitter.com
+func cmdRemove(cmd *cli.Cmd) {
+	cmd.Spec = "ACCOUNT..."
+	var (
+		accounts = cmd.StringsArg("ACCOUNT", nil, "Account names to remove")
+	)
+	cmd.Action = func() {
+		fmt.Printf("Deleting accounts: %v", *accounts)
+	}
+}
+```
+
+
+## Comparison to Other Tools
+There are several tools in the Go ecosystem to facilitate the creation of
+command line tools.  The following is a comparison to the built-in flag package
+as well as the popular urfave/cli (formerly known as codegangsta/cli):
+
+|                                                                     | mow.cli | urfave/cli | flag |
+|---------------------------------------------------------------------|---------|------------|------|
+| Contextual help                                                     | ✓       | ✓          |      |
+| Commands                                                            | ✓       | ✓          |      |
+| Option folding `-xyz`                                               | ✓       |            |      |
+| Option value folding `-fValue`                                      | ✓       |            |      |
+| Option exclusion `--start ❘ --stop`                                 | ✓       |            |      |
+| Option dependency `[-a -b]` or `[-a [-b]]`                          | ✓       |            |      |
+| Arguments validation `SRC DST`                                      | ✓       |            |      |
+| Argument optionality `SRC [DST]`                                    | ✓       |            |      |
+| Argument repetition `SRC... DST`                                    | ✓       |            |      |
+| Option/argument dependency `SRC [-f DST]`                           | ✓       |            |      |
+| Any combination of the above `[-d ❘ --rm] IMAGE [COMMAND [ARG...]]` | ✓       |            |      |
+
+Unlike the simple packages above, docopt is another library that supports rich
+set of flag and argument validation. It does, however, fall short for many use
+cases including:
+
+|                            | mow.cli | docopt |
+|----------------------------|---------|--------|
+| Contextual help            | ✓       |        |
+| Backtracking `SRC... DST`  | ✓       |        |
+| Backtracking `[SRC] DST`   | ✓       |        |
+| Branching `(SRC ❘ -f DST)` | ✓       |        |
+
+
+## Installation
+To install this package, run the following:
+
+```shell
+go get {{.Import}}
+```
+
+# Package Documentation
+
+<!-- Do NOT edit past here. This is replaced by the contents of the package documentation -->
+{{.Doc}}
+
+{{if .Bugs}}
+# Bugs
+{{range .Bugs}}* {{.}}{{end}}
+{{end}}
+
+## License
+This work is published under the MIT license.
+
+Please see the `LICENSE` file for details.
+
+* * *
+Automatically generated by [autoreadme](https://github.com/jimmyfrasche/autoreadme) on {{.Today}}

--- a/doc.go
+++ b/doc.go
@@ -1,518 +1,658 @@
 /*
-Package cli provides a framework to build command line applications in Go with most of the burden of arguments parsing and validation
-placed on the framework instead of the user.
+Package cli provides a framework to build command line applications in Go with
+most of the burden of arguments parsing and validation placed on the framework
+instead of the user.
+
 
 
 Basics
 
-You start by creating an application by passing a name and a description:
+To create a new application, initialize an app with cli.App. Specify a name and
+a brief description for the application:
 
-	cp = cli.App("cp", "Copy files around")
+    cp := cli.App("cp", "Copy files around")
 
-To attach the code to execute when the app is launched, assign a function to the Action field:
-	cp.Action = func() {
-		fmt.Printf("Hello world\n")
-	}
+To attach code to execute when the app is launched, assign a function to the
+Action field:
 
-Finally, in your main func, call Run on the app:
+    cp.Action = func() {
+        fmt.Printf("Hello world\n")
+    }
 
-	cp.Run(os.Args)
+To assign a version to the application, use Version method and specify the flags
+that will be used to invoke the version command:
+
+    cp.Version("v version", "cp 1.2.3")
+
+Finally, in the main func, call Run passing in the arguments for parsing:
+
+    cp.Run(os.Args)
+
+
 
 Options
 
-To add a (global) option, call one of the (String[s]|Int[s]|Bool)Opt methods on the app:
+To add one or more command line options (also known as flags), use one of the
+short-form StringOpt, StringsOpt, IntOpt, IntsOpt, or BoolOpt methods on App (or
+Cmd if adding flags to a command or subcommand). For example, to add a boolean
+flag to the cp command that specifies recursive mode, use the following:
 
-	recursive := cp.BoolOpt("R recursive", false, "recursively copy the src to dst")
+    recursive := cp.BoolOpt("R recursive", false, "recursively copy the src to dst")
 
-* The first argument is a space separated list of names for the option without the dashes
+The first argument is a space separated list of names for the option without the
+dashes. Generally, both short and long forms are specified, but this is not
+mandatory. Additional names (aliases) can be provide if desired, but these are
+not shown in the auto-generated help. The second argument is the default value
+for the option if it is not supplied by the user. And, the third argument is the
+description to be shown in help messages.
 
-* The second parameter is the default value for the option
+There is also a second set of methods on App called String, Strings, Int, Ints,
+and Bool, which accept a long-form struct of the type: cli.StringOpt,
+cli.StringsOpt, cli.IntOpt, cli.IntsOpt, cli.BoolOpt. The struct describes the
+option and allows the use of additional features not available in the short-form
+methods described above:
 
-* The third parameter is the option description, as will be shown in the help messages
+    recursive = cp.Bool(cli.BoolOpt{
+        Name:       "R recursive",
+        Value:      false,
+        Desc:       "copy src files recursively",
+        EnvVar:     "VAR_RECURSIVE",
+        SetByUser:  &recursiveSetByUser,
+    })
 
-There is also a second set of methods Bool, String, Int, Strings and Ints, which accepts a struct describing the option:
+Two features, EnvVar and SetByUser, can be defined in the long-form struct
+method. EnvVar is a space separated list of environment variables used to
+initialize the option if a value is not provided by the user. When help messages
+are shown, the value of any environment variables will be displayed. SetByUser
+is a pointer to a boolean variable that is set to true if the user specified the
+value on the command line. This can be useful to determine if the value of the
+option was explicitly set by the user or set via the default value.
 
-	recursive = cp.Bool(BoolOpt{
-		Name:  "R",
-		Value: false,
-		Desc:  "copy src files recursively",
-		EnvVar: "",
-	})
+The result of both short- and long-forms is a pointer to a value, which will be
+populated after the command line arguments are parsed. You can only access the
+values stored in the pointers in the Action func, which is invoked after
+argument parsing has been completed. This precludes using the value of one
+option as the default value of another.
 
-There EnvVar field is a space separated list of environment variables names to be used to initialize the option.
+On the command line, the following syntaxes are supported when specifying
+options.
 
-The result is a pointer to a value which will be populated after parsing the command line arguments.
-You can access the values in the Action func.
+Boolean options:
 
-In the command line, mow.cli accepts the following syntaxes
+    -f         single dash one letter name
+    -f=false   single dash one letter name, equal sign followed by true or false
+    --force    double dash for longer option names
+    -it        single dash for multiple one letter names (option folding), this is equivalent to: -i -t
 
-* For boolean options:
+String and int options:
 
-	-f : a single dash for the one letter names
-	-f=false : a single dash for the one letter names, equal sign followed by true or false
-	--force :  double dash for longer option names
-	-it : mow.cli supports option folding, this is equivalent to: -i -t
+    -e=value       single dash one letter name, equal sign, followed by the value
+    -e value       single dash one letter name, space followed by the value
+    -Ivalue        single dash one letter name, immediately followed by the value
+    --extra=value  double dash for longer option names, equal sign followed by the value
+    --extra value  double dash for longer option names, space followed by the value
 
-* For string, int options:
+Slice options (StringsOpt, IntsOpt) where option is repeated to accumulate
+values in a slice:
 
-	-e=value : single dash for one letter names, equal sign followed by the value
-	-e value : single dash for one letter names, space followed by the value
-	-Ivalue : single dash for one letter names immediately followed by the value
-	--extra=value : double dash for longer option names, equal sign followed by the value
-	--extra value : double dash for longer option names, space followed by the value
+    -e PATH:/bin    -e PATH:/usr/bin     resulting slice contains ["/bin", "/usr/bin"]
+    -ePATH:/bin     -ePATH:/usr/bin      resulting slice contains ["/bin", "/usr/bin"]
+    -e=PATH:/bin    -e=PATH:/usr/bin     resulting slice contains ["/bin", "/usr/bin"]
+    --env PATH:/bin --env PATH:/usr/bin  resulting slice contains ["/bin", "/usr/bin"]
+    --env=PATH:/bin --env=PATH:/usr/bin  resulting slice contains ["/bin", "/usr/bin"]
 
-* For slice options (StringsOpt, IntsOpt): repeat the option to accumulate the values in the resulting slice:
 
-	-e PATH:/bin -e PATH:/usr/bin : resulting slice contains ["/bin", "/usr/bin"]
 
 Arguments
 
-To accept arguments, you need to explicitly declare them by calling one of the (String[s]|Int[s]|Bool)Arg methods on the app:
+To add one or more command line arguments (not prefixed by dashes), use one of
+the short-form StringArg, StringsArg, IntArg, IntsArg, or BoolArg methods on App
+(or Cmd if adding arguments to a command or subcommand). For example, to add two
+string arguments to our cp command, use the following calls:
 
-	src := cp.StringArg("SRC", "", "the file to copy")
-	dst := cp.StringArg("DST", "", "the destination")
+    src := cp.StringArg("SRC", "", "the file to copy")
+    dst := cp.StringArg("DST", "", "the destination")
 
-* The first argument is the argument name as will be shown in the help messages
+The first argument is the name of the argument as displayed in help messages.
+Argument names must be specified as all uppercase.  The second argument is the
+default value for the argument if it is not supplied. And the third, argument is
+the description to be shown in help messages.
 
-* The second parameter is the default value for the argument
+There is also a second set of methods on App called String, Strings, Int, Ints,
+and Bool, which accept a long-form struct of the type: cli.StringArg,
+cli.StringsArg, cli.IntArg, cli.IntsArg, cli.BoolArg. The struct describes the
+arguments and allows the use of additional features not available in the
+short-form methods described above:
 
-* The third parameter is the argument description, as will be shown in the help messages
+    src = cp.Strings(StringsArg{
+        Name:      "SRC",
+        Desc:      "The source files to copy",
+        Value:     "default value",
+        EnvVar:    "VAR1 VAR2",
+        SetByUser: &srcSetByUser,
+    })
 
-There is also a second set of methods Bool, String, Int, Strings and Ints, which accepts structs describing the argument:
+Two features, EnvVar and SetByUser, can be defined in the long-form struct
+method. EnvVar is a space separated list of environment variables used to
+initialize the argument if a value is not provided by the user. When help
+messages are shown, the value of any environment variables will be displayed.
+SetByUser is a pointer to a boolean variable that is set to true if the user
+specified the value on the command line. This can be useful to determine if the
+value of the argument was explicitly set by the user or set via the default
+value.
 
-	src = cp.Strings(StringsArg{
-		Name:  "SRC",
-		Desc:  "The source files to copy",
-		Value: "",
-		EnvVar: "",
-    	SetByUser: &srcSetByUser,
-	})
-
-The Value field is where you can set the initial value for the argument.
-
-EnvVar accepts a space separated list of environment variables names to be used to initialize the argument.
-
-If SetByUser is specified (by passing a pointer to a bool variable), it will be set to true only if the user explicitly sets the argument.
-
-
-The result is a pointer to a value that will be populated after parsing the command line arguments.
-You can access the values in the Action func.
+The result of both short- and long-forms is a pointer to a value which will be
+populated after the command line arguments are parsed. You can only access the
+values stored in the pointers in the Action func, which is invoked after
+argument parsing has been completed. This precludes using the value of one
+argument as the default value of another.
 
 
 
 Operators
 
-The -- operator marks the end of options.
-Everything that follow will be treated as an argument,
-even if starts with a dash.
+The -- operator marks the end of command line options. Everything that follows
+will be treated as an argument, even if starts with a dash.  For example, the
+standard POSIX touch command, which takes a filename as an argument (and
+possibly other options that we'll ignore here), could be defined as:
 
-For example, given the touch command which takes a filename as an argument (and possibly other options):
+    file := cp.StringArg("FILE", "", "the file to create")
 
+If we try to create a file named "-f" via our touch command:
 
-	file := cp.StringArg("FILE", "", "the file to create")
+    $ touch -f
 
+It will fail because the -f will be parsed as an option, not as an argument. The
+fix is to insert -- after all flags have been specified, so the remaining
+arguments are parsed as arguments instead of options as follows:
 
-If we try to create a file named -f this way:
+    $ touch -- -f
 
-
-	touch -f
-
-Would fail, because -f will be parsed as an option not as an argument.
-The fix is to prefix the filename with the -- operator:
-
-
-	touch -- -f
+This ensures the -f is parsed as an argument instead of a flag named f.
 
 
 
 Commands
 
-mow.cli supports nesting commands and sub commands.
-Declare a top level command by calling the Command func on the app struct, and a sub command by calling
-the Command func on the command struct:
+This package supports nesting of commands and subcommands. Declare a top-level
+command by calling the Command func on the top-level App struct. For example,
+the following creates an application called docker that will have one command
+called run:
 
-	docker := cli.App("docker", "A self-sufficient runtime for linux containers")
+    docker := cli.App("docker", "A self-sufficient runtime for linux containers")
 
-	docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
-		// initialize the run command here
-	})
+    docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
+        // initialize the run command here
+    })
 
-* The first argument is the command name, as will be shown in the help messages and as will need to be input by the user in the command line to call the command
+The first argument is the name of the command the user will specify on the
+command line to invoke this command.  The second argument is the description of
+the command shown in help messages.  And, the last argument is a CmdInitializer,
+which is a function that receives a pointer to a Cmd struct representing the
+command.
 
-* The second argument is the command description as will be shown in the help messages
+Within this function, define the options and arguments for the command by
+calling the same methods as you would with top-level App struct (BoolOpt,
+StringArg, ...).  To execute code when the command is invoked, assign a function
+to the Action field of the Cmd struct. Within that function, you can safely
+refer to the options and arguments as command line parsing will be completed at
+the time the function is invoked:
 
-* The third argument is a CmdInitializer, a function that receives a pointer to a Cmd struct representing the command.
-In this function, you can add options and arguments by calling the same methods as you would with an app struct (BoolOpt, StringArg, ...).
-You would also assign a function to the Action field of the Cmd struct for it to be executed when the command is invoked.
+    docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
+        var (
+            detached = cmd.BoolOpt("d detach", false, "Run container in background")
+            memory   = cmd.StringOpt("m memory", "", "Set memory limit")
+            image    = cmd.StringArg("IMAGE", "", "The image to run")
+        )
 
-	docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
-		detached := cmd.BoolOpt("d detach", false, "Detached mode: run the container in the background and print the new container ID")
-		memory := cmd.StringOpt("m memory", "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)")
+        cmd.Action = func() {
+            if *detached {
+                // do something
+            }
+            runContainer(*image, *detached, *memory)
+        }
+    })
 
-		image := cmd.StringArg("IMAGE", "", "The image to run")
+Optionally, to provide a more extensive description of the command, assign a
+string to LongDesc, which is displayed when a user invokes --help. A LongDesc
+can be provided for Cmds as well as the top-level App:
 
-		cmd.Action = func() {
-			if *detached {
-				//do something
-			}
-			runContainer(*image, *detached, *memory)
-		}
-	})
+    cmd.LongDesc = `Run a command in a new container
 
-You can also add sub commands by calling Command on the Cmd struct:
+    With the docker run command, an operator can add to or override the
+    image defaults set by a developer. And, additionally, operators can
+    override nearly all the defaults set by the Docker runtime itself.
+    The operator’s ability to override image and Docker runtime defaults
+    is why run has more options than any other docker command.`
 
-	bzk.Command("job", "actions on jobs", func(cmd *cli.Cmd) {
-		cmd.Command("list", "list jobs", listJobs)
-		cmd.Command("start", "start a new job", startJob)
-		cmd.Command("log", "show a job log", nil)
-	})
+Subcommands can be added by calling Command on the Cmd struct. They can by
+defined to any depth if needed:
 
-This could go on to any depth if need be.
+    docker.Command("job", "actions on jobs", func(job *cli.Cmd) {
+        job.Command("list", "list jobs", listJobs)
+        job.Command("start", "start a new job", startJob)
+        job.Command("log", "log commands", func(log *cli.Cmd) {
+            log.Command("show", "show logs", showLog)
+            log.Command("clear", "clear logs", clearLog)
+        })
+    })
 
-mow.cli also supports command aliases. For example:
+Command and subcommand aliases are also supported. To define one or more
+aliases, specify a space-separated list of strings to the first argument of
+Command:
 
-	app.Command("start run r", "start doing things", cli.ActionCommand(func() { start() }))
+    job.Command("start run r", "start a new job", startJob)
 
-will alias `start`, `run`, and `r` to the same action. Aliases also work for
-subcommands:
+With the command structure defined above, users can invoke the app in a variety
+of ways:
 
-	app.Command("job j", "actions on jobs", func(cmd *cli.Cmd) {
-		cmd.Command("list ls", "list jobs", func(cmd *cli.Cmd) {
-			cmd.Action = func() {
-				list()
-			}
-		})
-	})
+    $ docker job list
+    $ docker job start
+    $ docker job run   # using the alias we defined
+    $ docker job r     # using the alias we defined
+    $ docker job log show
+    $ docker job log clear
 
-which then allows you to invoke the subcommand as `app job list`, `app job ls`,
-`app j ls`, or `app j list`.
+As a convenience, to assign an Action to a func with no arguments, use
+ActionCommand when defining the Command. For example, the following two
+statements are equivalent:
 
+    app.Command("list", "list all configs", cli.ActionCommand(list))
 
-As a side-note: it may seem a bit weird the way mow.cli uses a function to initialize a command
-instead of just returning the command struct.
+    // Exactly the same as above, just more verbose
+    app.Command("list", "list all configs", func(cmd *cli.Cmd)) {
+        cmd.Action = func() {
+            list()
+        }
+    }
 
-The motivation behind this choice is scoping: as with the standard flag package, adding an option or an argument
-returns a pointer to a value which will be populated when the app is run.
+Please note that options, arguments, specs, and long descriptions cannot be
+provided when using ActionCommand. This is intended for very simple command
+invocations that take no arguments.
 
-Since you'll want to store these pointers in variables, and to avoid having dozens of them in the same scope (the main func for example or as global variables),
-mow.cli's API was specifically tailored to take a func parameter (called CmdInitializer) which accepts the command struct.
-
-This way, the command specific variables scope is limited to this function.
-
-Custom types
-
-Out of the box, mow.cli supports the following types for options and arguments: bool, string, int, strings (slice of strings) and ints (slice of ints)
-
-You can however extend mow.cli to handle other types, e.g. `time.Duration`, `float64`, or even your own struct types for example.
-
-To do so, you'll need to:
-
-* implement the `flag.Value` interface for the custom type
-
-* declare the option or the flag using `VarOpt`, `VarArg` for the short hands, and `Var` for the full form.
-
-Here's an example:
-
-
-	// Declare your type
-	type Duration time.Duration
-
-	// Make it implement flag.Value
-	func (d *Duration) Set(v string) error {
-		parsed, err := time.ParseDuration(v)
-		if err != nil {
-			return err
-		}
-		*d = Duration(parsed)
-		return nil
-	}
-
-	func (d *Duration) String() string {
-		duration := time.Duration(*d)
-		return duration.String()
-	}
-
-	func main() {
-		duration := Duration(0)
-
-		app := App("var", "")
-
-		app.VarArg("DURATION", &duration, "")
-
-		app.Run([]string{"cp", "1h31m42s"})
-	}
-
-Boolean custom types
-
-To make your custom type behave as a boolean option, i.e. doesn't take a value, it has to implement a IsBoolFlag method that returns true:
+Finally, as a side-note, it may seem a bit weird that this package uses a
+function to initialize a command instead of simply returning a command struct.
+The motivation behind this API decision is scoping: as with the standard flag
+package, adding an option or an argument returns a pointer to a value which will
+be populated when the app is run.  Since you'll want to store these pointers in
+variables, and to avoid having dozens of them in the same scope (the main func
+for example or as global variables), this API was specifically tailored to take
+a func parameter (called CmdInitializer), which accepts the command struct. With
+this design, the command's specific variables are limited in scope to this
+function.
 
 
-	type BoolLike int
-
-
-	func (d *BoolLike) IsBoolFlag() bool {
-		return true
-	}
-
-
-Multi-valued custom type
-
-To make your custom type behave as a multi-valued option or argument, i.e. takes multiple values,
-it has to implement a `Clear` method which will be called whenever the values list needs to be cleared,
-e.g. when the value was initially populated from an environment variable, and then explicitly set from the CLI:
-
-	type Durations []time.Duration
-
-	// Make it implement flag.Value
-	func (d *Durations) Set(v string) error {
-		parsed, err := time.ParseDuration(v)
-		if err != nil {
-			return err
-		}
-		*d = append(*d, Duration(parsed))
-		return nil
-	}
-
-	func (d *Durations) String() string {
-		return fmt.Sprintf("%v", *d)
-	}
-
-
-	// Make it multi-valued
-	func (d *Durations) Clear() {
-		*d = []Duration{}
-	}
 
 Interceptors
 
-It is possible to define snippets of code to be executed before and after a command or any of its sub commands is executed.
+Interceptors, or hooks, can be defined to be executed before and after a command
+or when any of its subcommands are executed.  For example, the following app
+defines multiple commands as well as a global flag which toggles verbosity:
+
+    app := cli.App("app", "bla bla")
+    verbose := app.BoolOpt("verbose v", false, "Enable debug logs")
+
+    app.Command("command1", "...", func(cmd *cli.Cmd) {
+        if (*verbose) {
+            logrus.SetLevel(logrus.DebugLevel)
+        }
+    })
+
+    app.Command("command2", "...", func(cmd *cli.Cmd) {
+        if (*verbose) {
+            logrus.SetLevel(logrus.DebugLevel)
+        }
+    })
+
+Instead of duplicating the check for the verbose flag and setting the debug
+level in every command (and its sub-commands), a Before interceptor can be set
+on the top-level App instead:
+
+    app.Before = func() {
+        if (*verbose) {
+            logrus.SetLevel(logrus.DebugLevel)
+        }
+    }
+
+Whenever a valid command is called by the user, all the Before interceptors
+defined on the app and the intermediate commands will be called, in order from
+the root to the leaf.
+
+Similarly, to execute a hook after a command has been called, e.g. to cleanup
+resources allocated in Before interceptors, simply set the After field of the
+App struct or any other Command. After interceptors will be called, in order,
+from the leaf up to the root (the opposite order of the Before interceptors).
+
+The following diagram shows when and in which order multiple Before and After
+interceptors are executed:
+
+    +------------+    success    +------------+   success   +----------------+     success
+    | app.Before +---------------> cmd.Before +-------------> sub_cmd.Before +---------+
+    +------------+               +-+----------+             +--+-------------+         |
+                                   |                           |                     +-v-------+
+                     error         |           error           |                     | sub_cmd |
+           +-----------------------+   +-----------------------+                     | Action  |
+           |                           |                                             +-+-------+
+    +------v-----+               +-----v------+             +----------------+         |
+    | app.After  <---------------+ cmd.After  <-------------+  sub_cmd.After <---------+
+    +------------+    always     +------------+    always   +----------------+      always
 
-For example, given an app with multiple commands but with a global flag which toggles a verbose mode:
-
-
-	app := cli.App("app", "bla bla")
-	verbose := app.Bool(cli.BoolOpt{
-		Name:  "verbose",
-		Value: false,
-		Desc:  "Enable debug logs",
-	})
-
-	app.Command("command1", "...", func(cmd *cli.Cmd) {
-
-	})
-
-	app.Command("command2", "...", func(cmd *cli.Cmd) {
-
-	})
-
-Instead of repeating yourself by checking if the verbose flag is set or not, and setting the debug level in every command (and its sub-commands),
-a before interceptor can be set on the `app` instead:
-
-	app.Before = func() {
-		if (*verbose) {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
-	}
-
-Whenever a valid command is called by the user, all the before interceptors defined on the app and the intermediate commands
-will be called, in order from the root to the leaf.
-
-Similarly, if you need to execute a code snippet after a command has been called, e.g. to cleanup resources allocated in before interceptors,
-simply set the After field of the app struct or any other command.
-
-After interceptors will be called, in order from the leaf up to the root (the opposite order of the Before interceptors).
-
-Here's a diagram which shows in when and in which order multiple Before and After interceptors get executed:
-
-	+------------+    success    +------------+   success   +----------------+     success
-	| app.Before +---------------> cmd.Before +-------------> sub_cmd.Before +---------+
-	+------------+               +-+----------+             +--+-------------+         |
-	                               |                           |                     +-v-------+
-	                 error         |           error           |                     | sub_cmd |
-	       +-----------------------+   +-----------------------+                     | Action  |
-	       |                           |                                             +-+-------+
-	+------v-----+               +-----v------+             +----------------+         |
-	| app.After  <---------------+ cmd.After  <-------------+  sub_cmd.After <---------+
-	+------------+    always     +------------+    always   +----------------+      always
-
-Spec
-
-An app or command's call syntax can be customized using spec strings.
-This can be useful to indicate that an argument is optional for example, or that 2 options are mutually exclusive.
-
-You can set a spec string on:
-
-* The app: to configure the syntax for global options and arguments
-
-* A command: to configure the syntax for that command's options and arguments
-
-In both cases, a spec string is assigned to the Spec field:
-
-	cp := cli.App("cp", "Copy files around")
-	cp.Spec = "[-R [-H | -L | -P]]"
-
-And:
-
-	docker := cli.App("docker", "A self-sufficient runtime for linux containers")
-	docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
-		cmd.Spec = "[-d|--rm] IMAGE [COMMAND [ARG...]]"
-		:
-		:
-	}
-
-The spec syntax is mostly based on the conventions used in POSIX command line apps help messages and man pages:
-
-Options
-
-You can use both short and long option names in spec strings:
-	x.Spec="-f"
-And:
-	x.Spec="--force"
-
-In both cases, we required that the f or force flag be set
-
-Any option you reference in a spec string MUST be explicitly declared, otherwise mow.cli will panic:
-
-	x.BoolOpt("f force", ...)
-
-Arguments
-
-Arguments are all-uppercased words:
-	x.Spec="SRC DST"
-This spec string will force the user to pass exactly 2 arguments, SRC and DST
-
-Any argument you reference in a spec string MUST be explicitly declared, otherwise mow.cli will panic:
-
-	x.StringArg("SRC", ...)
-	x.StringArg("DST", ...)
-
-Ordering
-
-Except for options, The order of the elements in a spec string is respected and enforced when parsing the command line arguments:
-
-	x.Spec = "-f -g SRC -h DST"
-
-Consecutive options (-f and -g for example) get parsed regardless of the order they are specified in (both "-f=5 -g=6" and "-g=6 -f=5" are valid).
-
-Order between options and arguments is significant (-f and -g must appear before the SRC argument).
-
-Same goes for arguments, where SRC must appear before DST.
-
-Optionality
-
-You can mark items as optional in a spec string by enclosing them in square brackets :[...]
-	x.Spec = "[-x]"
-
-Choice
-
-You can use the | operator to indicate a choice between two or more items
-	x.Spec = "--rm | --daemon"
-	x.Spec = "-H | -L | -P"
-	x.Spec = "-t | DST"
-
-Repetition
-
-You can use the ... postfix operator to mark an element as repeatable:
-	x.Spec="SRC..."
-	x.Spec="-e..."
-
-Grouping
-
-You can group items using parenthesis. This is useful in combination with the choice and repetition operators (| and ...):
-	x.Spec = "(-e COMMAND)... | (-x|-y)"
-The parenthesis in the example above serve to mark that it is the sequence of a -e flag followed by an argument that is repeatable, and that
-all that is mutually exclusive to a choice between -x and -y options.
-
-Option group
-
-This is a shortcut to declare a choice between multiple options:
-	x.Spec = "-abcd"
-Is equivalent to:
-	x.Spec = "(-a | -b | -c | -d)..."
-I.e. any combination of the listed options in any order, with at least one option.
-
-All options
-
-Another shortcut:
-	x.Spec = "[OPTIONS]"
-This is a special syntax (the square brackets are not for marking an optional item, and the uppercased word is not for an argument).
-This is equivalent to a repeatable choice between all the available options.
-For example, if an app or a command declares 4 options a, b, c and d, [OPTIONS] is equivalent to
-	x.Spec = "[-a | -b | -c | -d]..."
-
-Inline option values
-
-You can use the =<some-text> notation right after an option (long or short form) to give an inline description or value.
-An example:
-	x.Spec = "[ -a=<absolute-path> | --timeout=<in seconds> ] ARG"
-The inline values are ignored by the spec parser and are just there for the final user as a contextual hint.
-
-Operators
-
-The `--` operator can be used in a spec string to automatically treat everything following it as an options.
-
-In other words, placing a `--` in the spec string automatically inserts a `--` in the same position in the program call arguments.
-
-This lets you write programs like the `time` utility for example:
-
-	x.Spec = "time -lp [-- CMD [ARG...]]"
-
-
-Spec Grammar
-
-Here's the EBNF grammar for the Specs language:
-
-	spec         -> sequence
-	sequence     -> choice*
-	req_sequence -> choice+
-	choice       -> atom ('|' atom)*
-	atom         -> (shortOpt | longOpt | optSeq | allOpts | group | optional) rep?
-	shortOp      -> '-' [A-Za-z]
-	longOpt      -> '--' [A-Za-z][A-Za-z0-9]*
-	optSeq       -> '-' [A-Za-z]+
-	allOpts      -> '[OPTIONS]'
-	group        -> '(' req_sequence ')'
-	optional     -> '[' req_sequence ']'
-	rep          -> '...'
-
-And that's it for the spec language.
-You can combine these few building blocks in any way you want (while respecting the grammar above) to construct sophisticated validation constraints
-(don't go too wild though).
-
-Behind the scenes, mow.cli parses the spec string and constructs a finite state machine to be used to parse the command line arguments.
-mow.cli also handles backtracking, and so it can handle tricky cases, or what I like to call "the cp test"
-	cp SRC... DST
-Without backtracking, this deceptively simple spec string cannot be parsed correctly.
-For instance, docopt can't handle this case, whereas mow.cli does.
-
-Default spec
-
-By default, and unless a spec string is set by the user, mow.cli auto-generates one for the app and every command using this logic:
-
-* Start with an empty spec string
-
-* If at least one option was declared, append "[OPTIONS]" to the spec string
-
-* For every declared argument, append it, in the order of declaration, to the spec string
-
-For example, given this command declaration:
-	docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
-		detached := cmd.BoolOpt("d detach", false, "Detached mode: run the container in the background and print the new container ID")
-		memory := cmd.StringOpt("m memory", "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)")
-
-		image := cmd.StringArg("IMAGE", "", "")
-		args := cmd.StringsArg("ARG", "", "")
-	})
-The auto-generated spec string would be:
-	[OPTIONS] IMAGE ARG
-
-Which should suffice for simple cases. If not, the spec string has to be set explicitly.
 
 
 Exiting
 
-mow.cli provides the Exit function which accepts an exit code and exits the app with the provided code.
+To exit the application, use cli.Exit function, which accepts an exit code and
+exits the app with the provided code.  It is important to use cli.Exit instead
+of os.Exit as the former ensures that all of the After interceptors are executed
+before exiting.
 
-You are highly encouraged to call cli.Exit instead of os.Exit for the After interceptors to be executed.
+    cli.Exit(1)
+
+
+
+Spec Strings
+
+An App or Command's invocation syntax can be customized using spec strings. This
+can be useful to indicate that an argument is optional or that two options are
+mutually exclusive.  The spec string is one of the key differentiators between
+this package and other CLI packages as it allows the developer to express usage
+in a simple, familiar, yet concise grammar.
+
+To define option and argument usage for the top-level App, assign a spec string
+to the App's Spec field:
+
+    cp := cli.App("cp", "Copy files around")
+    cp.Spec = "[-R [-H | -L | -P]]"
+
+Likewise, to define option and argument usage for a command or subcommand,
+assign a spec string to the Command's Spec field:
+
+    docker := cli.App("docker", "A self-sufficient runtime for linux containers")
+    docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
+        cmd.Spec = "[-d|--rm] IMAGE [COMMAND [ARG...]]"
+        :
+        :
+    }
+
+The spec syntax is mostly based on the conventions used in POSIX command line
+applications (help messages and man pages). This syntax is described in full
+below. If a user invokes the app or command with the incorrect syntax, the app
+terminates with a help message showing the proper invocation. The remainder of
+this section describes the many features and capabilities of the spec string
+grammar.
+
+Options can use both short and long option names in spec strings.  In the
+example below, the option is mandatory and must be provided.  Any options
+referenced in a spec string MUST be explicitly declared, otherwise this package
+will panic. I.e. for each item in the spec string, a corresponding *Opt or *Arg
+is required:
+
+    x.Spec = "-f"  // or x.Spec = "--force"
+    forceFlag := x.BoolOpt("f force", ...)
+
+Arguments are specified with all-uppercased words.  In the example below, both
+SRC and DST must be provided by the user (two arguments).  Like options, any
+argument referenced in a spec string MUST be explicitly declared, otherwise this
+package will panic:
+
+    x.Spec="SRC DST"
+    src := x.StringArg("SRC", ...)
+    dst := x.StringArg("DST", ...)
+
+With the exception of options, the order of the elements in a spec string is
+respected and enforced when command line arguments are parsed.  In the example
+below, consecutive options (-f and -g) are parsed regardless of the order they
+are specified (both "-f=5 -g=6" and "-g=6 -f=5" are valid).  Order between
+options and arguments is significant (-f and -g must appear before the SRC
+argument). The same holds true for arguments, where SRC must appear before DST:
+
+    x.Spec = "-f -g SRC -h DST"
+    var (
+        factor = x.IntOpt("f", 1, "Fun factor (1-5)")
+        games  = x.IntOpt("g", 1, "# of games")
+        health = x.IntOpt("h", 1, "# of hosts")
+        src    = x.StringArg("SRC", ...)
+        dst    = x.StringArg("DST", ...)
+    )
+
+Optionality of options and arguments is specified in a spec string by enclosing
+the item in square brackets []. If the user does not provide an optional value,
+the app will use the default value specified when the argument was defined. In
+the example below, if -x is not provided, heapSize will default to 1024:
+
+    x.Spec = "[-x]"
+    heapSize := x.IntOpt("x", 1024, "Heap size in MB")
+
+Choice between two or more items is specified in a spec string by separating
+each choice with the | operator. Choices are mutually exclusive. In the examples
+below, only a single choice can be provided by the user otherwise the app will
+terminate displaying a help message on proper usage:
+
+    x.Spec = "--rm | --daemon"
+    x.Spec = "-H | -L | -P"
+    x.Spec = "-t | DST"
+
+Repetition of options and arguments is specified in a spec string with the ...
+postfix operator to mark an item as repeatable. Both options and arguments
+support repitition. In the example below, users may invoke the command with
+multiple -e options and multiple SRC arguments:
+
+    x.Spec = "-e... SRC..."
+
+    // Allows parsing of the following shell command:
+    //   $ app -eeeee file1 file2
+    //   $ app -e -e -e -e file1 file2
+
+Grouping of options and arguments is specified in a spec string with
+parenthesis.  When combined with the choice | and repetition ... operators,
+complex syntaxes can be created. The parenthesis in the example below indicate a
+repeatable sequence of a -e option followed by an argument, and that is mutually
+exclusive to a choice between -x and -y options.
+
+    x.Spec = "(-e COMMAND)... | (-x|-y)"
+
+    // Allows parsing of the following shell command:
+    //   $ app -e show -e add
+    //   $ app -y
+    // But not the following:
+    //   $ app -e show -x
+
+Option groups, or option folding, are a shorthand method to declaring a choice
+between multiple options.  I.e. any combination of the listed options in any
+order with at least one option selected. The following two statements are
+equivalent:
+
+    x.Spec = "-abcd"
+    x.Spec = "(-a | -b | -c | -d)..."
+
+Option groups are typically used in conjunction with optionality [] operators.
+I.e. any combination of the listed options in any order or none at all. The
+following two statements are equivalent:
+
+    x.Spec = "[-abcd]"
+    x.Spec = "[-a | -b | -c | -d]..."
+
+All of the options can be specified using a special syntax: [OPTIONS]. This is a
+special token in the spec string (not optionality and not an argument called
+OPTIONS). It is equivalent to an optional repeatable choice between all the
+available options. For example, if an app or a command declares 4 options a, b,
+c and d, then the following two statements are equivalent:
+
+    x.Spec = "[OPTIONS]"
+    x.Spec = "[-a | -b | -c | -d]..."
+
+Inline option values are specified in the spec string with the =<some-text>
+notation immediately following an option (long or short form) to provide users
+with an inline description or value. The actual inline values are ignored by the
+spec parser as they exist only to provide a contextual hint to the user. In the
+example below, "absolute-path" and "in seconds" are ignored by the parser:
+
+    x.Spec = "[ -a=<absolute-path> | --timeout=<in seconds> ] ARG"
+
+The -- operator can be used to automatically treat everything following it as
+arguments.  In other words, placing a -- in the spec string automatically
+inserts a -- in the same position in the program call arguments. This lets you
+write programs such as the POSIX time utility for example:
+
+    x.Spec = "-lp [-- CMD [ARG...]]"
+
+    // Allows parsing of the following shell command:
+    //   $ app -p ps -aux
+
+
+
+Spec Grammar
+
+Below is the full EBNF grammar for the Specs language:
+
+    spec         -> sequence
+    sequence     -> choice*
+    req_sequence -> choice+
+    choice       -> atom ('|' atom)*
+    atom         -> (shortOpt | longOpt | optSeq | allOpts | group | optional) rep?
+    shortOp      -> '-' [A-Za-z]
+    longOpt      -> '--' [A-Za-z][A-Za-z0-9]*
+    optSeq       -> '-' [A-Za-z]+
+    allOpts      -> '[OPTIONS]'
+    group        -> '(' req_sequence ')'
+    optional     -> '[' req_sequence ']'
+    rep          -> '...'
+
+By combining a few of these building blocks together (while respecting the
+grammar above), powerful and sophisticated validation constraints can be created
+in a simple and concise manner without having to define in code. This is one of
+the key differentiators between this package and other CLI packages. Validation
+of usage is handled entirely by the package through the spec string.
+
+Behind the scenes, this package parses the spec string and constructs a finite
+state machine used to parse the command line arguments. It also handles
+backtracking, which allows it to handle tricky cases, or what I like to call
+"the cp test":
+
+    cp SRC... DST
+
+Without backtracking, this deceptively simple spec string cannot be parsed
+correctly. For instance, docopt can't handle this case, whereas this package
+does.
+
+
+
+Default Spec
+
+By default an auto-generated spec string is created for the app and every
+command unless a spec string has been set by the user.  This can simplify use of
+the package even further for simple syntaxes.
+
+The following logic is used to create an auto-generated spec string: 1) start
+with an empty spec string, 2) if at least one option was declared, append
+"[OPTIONS]" to the spec string, and 3) for each declared argument, append it, in
+the order of declaration, to the spec string. For example, given this command
+declaration:
+
+    docker.Command("run", "Run a command in a new container", func(cmd *cli.Cmd) {
+        var (
+            detached = cmd.BoolOpt("d detach", false, "Run container in background")
+            memory   = cmd.StringOpt("m memory", "", "Set memory limit")
+            image    = cmd.StringArg("IMAGE", "", "The image to run")
+            args     = cmd.StringsArg("ARG", nil, "Arguments")
+        )
+    })
+
+The auto-generated spec string, which should suffice for simple cases, would be:
+
+    [OPTIONS] IMAGE ARG
+
+If additional constraints are required, the spec string must be set explicitly
+using the grammar documented above.
+
+
+
+Custom Types
+
+By default, the following types are supported for options and arguments: bool,
+string, int, strings (slice of strings), and ints (slice of ints).  You can,
+however, extend this package to handle other types, e.g. time.Duration, float64,
+or even your own struct types.
+
+To define your own custom type, you must implement the flag.Value interface for
+your custom type, and then declare the option or argument using VarOpt or VarArg
+respectively if using the short-form methods. If using the long-form struct,
+then use Var instead.
+
+The following example defines a custom type for a duration. It defines a
+duration argument that users will be able to invoke with strings in the form of
+"1h31m42s":
+
+    // Declare your type
+    type Duration time.Duration
+
+    // Make it implement flag.Value
+    func (d *Duration) Set(v string) error {
+        parsed, err := time.ParseDuration(v)
+        if err != nil {
+            return err
+        }
+        *d = Duration(parsed)
+        return nil
+    }
+
+    func (d *Duration) String() string {
+        duration := time.Duration(*d)
+        return duration.String()
+    }
+
+    func main() {
+        duration := Duration(0)
+        app := App("var", "")
+        app.VarArg("DURATION", &duration, "")
+        app.Run([]string{"cp", "1h31m42s"})
+    }
+
+To make a custom type to behave as a boolean option, i.e. doesn't take a value,
+it must implement the IsBoolFlag method that returns true:
+
+    type BoolLike int
+
+    func (d *BoolLike) IsBoolFlag() bool {
+        return true
+    }
+
+To make a custom type behave as a multi-valued option or argument, i.e. takes
+multiple values, it must implement the Clear method, which is called whenever
+the values list needs to be cleared, e.g. when the value was initially populated
+from an environment variable, and then explicitly set from the CLI:
+
+    type Durations []time.Duration
+
+    // Make it implement flag.Value
+    func (d *Durations) Set(v string) error {
+        parsed, err := time.ParseDuration(v)
+        if err != nil {
+            return err
+        }
+        *d = append(*d, Duration(parsed))
+        return nil
+    }
+
+    func (d *Durations) String() string {
+        return fmt.Sprintf("%v", *d)
+    }
+
+    // Make it multi-valued
+    func (d *Durations) Clear() {
+        *d = []Duration{}
+    }
+
+To hide the default value of a custom type, it must implement the IsDefault
+method that returns a boolean. The help message generator will use the return
+value to decide whether or not to display the default value to users:
+
+    type Action string
+
+    func (a *Action) IsDefault() bool {
+        return (*a) == "nop"
+    }
+
+
 */
 package cli


### PR DESCRIPTION
MOTIVATION

Prior to this set of changes, two sets of documentation had to be maintained:
the GitHub README.md and the Go package documentation in doc.go.  The README.md
file is a superset of documentation that includes the following items:

- Various badge icons (build, godoc, coverage)
- Getting started guide with sample applications
- Comparison to other CLI tools
- Installation instructions
- A copy of the package doc.go
- License information

Because a copy of doc.go was included in README.md, over time these two versions
have diverged.  Committers updating README.md would forget to submit the same
patches to doc.go and vice versa.  Further complicating the situation is that
GitHub markdown is more featureful (multi-level headings, lists, etc ...) than
the simple and straightforward Go doc standards.  Consequently, the package
documentation (doc.go) contained within README.md acquired additional markup,
further cementing the need to maintain two slightly different versions of the
package documentation.

Due to the above issues, contributing to the project's documentation was not an
easy task. If done properly, a contributor would have to update the README.md
document and then update the doc.go package documentation stripping out the
markdown.  This assumes the contributor was editing a portion of the docs that
had not diverged over time.  In that case, additional work was required to
synchronize the documents.

CHANGES

This commit includes several changes to improve the overall documentation of
the mow.cli project. Below is a short summary of each:

- To eliminate the need to maintain two sets of nearly identical docs, the
  README.md file is now autogenerated using the Go autoreadme package. This
  tool generates a README.md from a README.md.template file. The template
  file includes all of the original README.md content (described above), but
  also includes placeholders where the contents of doc.go are included when
  the file is generated.

- A new 'doc' target was added to the Makefile, which generates README.md for
  inclusion into the repository for GitHub.  No changes should ever be made
  directly to the README.md file anymore as they will be overwritten when
  'make doc' is executed.  All changes should either be performed in
  README.md.template or doc.go.

- Extensive edits to the Go package documentation, doc.go, were made to improve
  readability. This included numerous grammatical changes, rephrasing of
  sentences, ensuring consistency of examples, and rearrangement of the sections,
  so the docs were more accessible to new users.

               Old Ordering              New Ordering
               ============              ============
        	- Basics                  - Basics
        	- Options                 - Options
        	- Arguments               - Arguments
        	- Operators               - Operators
        	- Commands                - Commands
        	- Custom Types            - Interceptors
        	- Interceptors            - Exiting
        	- Spec                    - Spec Strings
        	- Spec Grammar            - Spec Grammar
        	- Default Spec            - Default Spec
        	- Exiting                 - Custom Types

- Extensive reformatting of doc.go to ensure compliance with the basic Go doc
  style recommendations.  This required eliminating extraneous headings and
  lists (bulleted and enumerated).  Documentation can still be well-written
  without these constructs.  By adhering to the Go doc guidelines, when the
  package documentation is included by autoreadme in the README.md, it looks
  natural and fits in with the overall look and feel of the original README.md
  document. In addition, the package Go doc looks significantly better than it 
  did before when viewed with 'godoc -http=:8000', so if this change is accepted,
  the docs on godoc.org will reflect this as well.

  One of the biggest challenges was dealing with the lack of multi-
  level headings in Go do.  With only a single level heading, its use must be
  frugal.  The prior README.md, however, made liberal use of sub-headings
  especially in the original Spec section.  I simplified that entire section
  by writing each of the subsections as a separate paragraph with a single
  example, which maintains a rhythm for the reader making it flow as well,
  or perhaps even better, than that original README.md. 

- An additional example application called "A Larger Multi-Command Example" was
  written to show an alternate way of specifying the command structure where
  all commands are defined together in a section, but their implementation is
  deferred to functions. As a newcomer evaluating various CLI tools, I initially
  dismissed mow.cli because I did not like the style of defining every command
  in a single function as portrayed in the examples contained within README.md.