### PR TITLE
Fix parsing of long option values containing = sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@ ineffassign:
 	ineffassign .
 
 readmecheck:
-	cp README.md README.original.md
+	sed '$ d' README.md > README.original.md
 	autoreadme -f
-	diff README.md README.original.md
+	sed '$ d' README.md > README.generated.md
+	diff README.generated.md README.original.md
 
 setup:
 	go get github.com/gordonklaus/ineffassign

--- a/internal/matcher/option.go
+++ b/internal/matcher/option.go
@@ -71,7 +71,7 @@ func (o *opt) Match(args []string, c *ParseContext) (bool, []string) {
 
 func (o *opt) matchLongOpt(args []string, idx int, c *ParseContext) (bool, int, []string) {
 	arg := args[idx]
-	kv := strings.Split(arg, "=")
+	kv := strings.SplitN(arg, "=", 2)
 	name := kv[0]
 	opt, found := o.index[name]
 	if !found {

--- a/internal/matcher/option_test.go
+++ b/internal/matcher/option_test.go
@@ -70,12 +70,17 @@ func TestOptMatcher(t *testing.T) {
 		val   []string
 	}{
 		{[]string{"-f", "x"}, []string{}, []string{"x"}},
+		{[]string{"-f", "x="}, []string{}, []string{"x="}},
 		{[]string{"-f=x", "y"}, []string{"y"}, []string{"x"}},
+		{[]string{"-f=x=", "y"}, []string{"y"}, []string{"x="}},
 		{[]string{"-fx", "y"}, []string{"y"}, []string{"x"}},
+		{[]string{"-fx=", "y"}, []string{"y"}, []string{"x="}},
 		{[]string{"-afx", "y"}, []string{"-a", "y"}, []string{"x"}},
 		{[]string{"-af", "x", "y"}, []string{"-a", "y"}, []string{"x"}},
 		{[]string{"--force", "x"}, []string{}, []string{"x"}},
+		{[]string{"--force", "x="}, []string{}, []string{"x="}},
 		{[]string{"--force=x", "y"}, []string{"y"}, []string{"x"}},
+		{[]string{"--force=x=", "y"}, []string{"y"}, []string{"x="}},
 	}
 
 	for _, cas := range cases {

--- a/internal/matcher/options_test.go
+++ b/internal/matcher/options_test.go
@@ -37,13 +37,18 @@ func TestOptsMatcher(t *testing.T) {
 		{[]string{"--force=false", "y"}, []string{"y"}, [][]string{{"false"}, nil}},
 
 		{[]string{"-g", "x"}, []string{}, [][]string{nil, {"x"}}},
+		{[]string{"-g", "x="}, []string{}, [][]string{nil, {"x="}}},
 		{[]string{"-g=x", "y"}, []string{"y"}, [][]string{nil, {"x"}}},
+		{[]string{"-g=x=", "y"}, []string{"y"}, [][]string{nil, {"x="}}},
 		{[]string{"-gx", "y"}, []string{"y"}, [][]string{nil, {"x"}}},
 		{[]string{"--green", "x"}, []string{}, [][]string{nil, {"x"}}},
+		{[]string{"--green", "x="}, []string{}, [][]string{nil, {"x="}}},
 		{[]string{"--green=x", "y"}, []string{"y"}, [][]string{nil, {"x"}}},
+		{[]string{"--green=x=", "y"}, []string{"y"}, [][]string{nil, {"x="}}},
 
 		{[]string{"-f", "-g", "x", "y"}, []string{"y"}, [][]string{{"true"}, {"x"}}},
 		{[]string{"-g", "x", "-f", "y"}, []string{"y"}, [][]string{{"true"}, {"x"}}},
+		{[]string{"-g", "x=", "-f", "y"}, []string{"y"}, [][]string{{"true"}, {"x="}}},
 		{[]string{"-fg", "x", "y"}, []string{"y"}, [][]string{{"true"}, {"x"}}},
 		{[]string{"-fgxxx", "y"}, []string{"y"}, [][]string{{"true"}, {"xxx"}}},
 	}


### PR DESCRIPTION
## Problem

The parsing fails when you a value containing `=` to a long option, e.g.:

```
app --ns=value=
```

## Fix

Correctly separate the option name from the option value by limiting the splits on `=` to 2.

Fixes #74