### PR TITLE
Skip validation in parents when help is requested for a command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.out
 README.generated.md
 README.original.md
 bin/
+.idea/

--- a/cli.go
+++ b/cli.go
@@ -77,7 +77,7 @@ func (cli *Cli) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
 }
 
 func (cli *Cli) versionSetAndRequested(args []string) bool {
-	return cli.version != nil && cli.isFlagSet(args, cli.version.option.Names)
+	return cli.version != nil && cli.isFirstItemAmong(args, cli.version.option.Names)
 }
 
 /*

--- a/commands.go
+++ b/commands.go
@@ -742,10 +742,6 @@ func (c *Cmd) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
 
 }
 
-func (c *Cmd) helpRequested(args []string) bool {
-	return c.isFirstItemAmong(args, []string{"-h", "--help"})
-}
-
 func (c *Cmd) helpIndex(args []string) int {
 	searchSet := []string{"-h", "--help"}
 	for i, arg := range args {

--- a/commands.go
+++ b/commands.go
@@ -648,13 +648,32 @@ func formatEnvVarsForHelp(envVars string) string {
 }
 
 func (c *Cmd) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
-	if c.helpRequested(args) {
+	helpIndex := c.helpIndex(args)
+	nargsLen := c.getOptsAndArgs(args)
+
+	if helpIndex >= 0 && helpIndex < nargsLen {
 		c.PrintLongHelp()
 		c.onError(errHelpRequested)
 		return nil
 	}
 
-	nargsLen := c.getOptsAndArgs(args)
+	// help was requested, but not for this command, skip the validation
+	if helpIndex >= 0 {
+		arg := args[nargsLen]
+		for _, sub := range c.commands {
+			if !sub.isAlias(arg) {
+				continue
+			}
+
+			if err := sub.doInit(); err != nil {
+				panic(err)
+			}
+
+			return sub.parse(args[nargsLen+1:], entry, nil, nil)
+		}
+		// impossible case
+		panic("wut")
+	}
 
 	if err := c.fsm.Parse(args[:nargsLen]); err != nil {
 		fmt.Fprintf(stdErr, "Error: %s\n", err.Error())
@@ -724,16 +743,31 @@ func (c *Cmd) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
 }
 
 func (c *Cmd) helpRequested(args []string) bool {
-	return c.isFlagSet(args, []string{"-h", "--help"})
+	return c.isFirstItemAmong(args, []string{"-h", "--help"})
 }
 
-func (c *Cmd) isFlagSet(args []string, searchArgs []string) bool {
+func (c *Cmd) helpIndex(args []string) int {
+	searchSet := []string{"-h", "--help"}
+	for i, arg := range args {
+		if arg == "--" {
+			return -1
+		}
+		for _, searchArg := range searchSet {
+			if arg == searchArg {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func (c *Cmd) isFirstItemAmong(args []string, searchSet []string) bool {
 	if len(args) == 0 {
 		return false
 	}
 
 	arg := args[0]
-	for _, searchArg := range searchArgs {
+	for _, searchArg := range searchSet {
 		if arg == searchArg {
 			return true
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/jawher/mow.cli
 
 require (
-	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v2 v2.2.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,16 +3,11 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
For example:

* The app has a required argument
* The app has a command

If the program is invoked with:

`app command --help`

Before the fix:

An incorrect usage error will be printed, with the help message of the app

After the fix:

The help message for the command will be printed.

Fixes #118
