### PR TITLE
Publish `Stderr` to allow testing help

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -86,7 +86,7 @@ In most cases the library users won't need to call this method, unless
 a more complex validation is needed.
 */
 func (cli *Cli) PrintVersion() {
-	fmt.Fprintln(stdErr, cli.version.version)
+	fmt.Fprintln(Stderr, cli.version.version)
 }
 
 /*
@@ -130,5 +130,6 @@ var exiter = func(code int) {
 
 var (
 	stdOut io.Writer = os.Stdout
-	stdErr io.Writer = os.Stderr
+	// Stderr is the writer used for printing help information.
+	Stderr io.Writer = os.Stderr
 )

--- a/cli_test.go
+++ b/cli_test.go
@@ -2329,7 +2329,7 @@ func setAndRestoreEnv(env map[string]string) func() {
 
 func captureAndRestoreOutput(out, err *string) func() {
 	oldStdOut := stdOut
-	oldStdErr := stdErr
+	oldStdErr := Stderr
 
 	if out == nil {
 		stdOut = ioutil.Discard
@@ -2337,14 +2337,14 @@ func captureAndRestoreOutput(out, err *string) func() {
 		stdOut = trapWriter(out)
 	}
 	if err == nil {
-		stdErr = ioutil.Discard
+		Stderr = ioutil.Discard
 	} else {
-		stdErr = trapWriter(err)
+		Stderr = trapWriter(err)
 	}
 
 	return func() {
 		stdOut = oldStdOut
-		stdErr = oldStdErr
+		Stderr = oldStdErr
 	}
 }
 

--- a/commands.go
+++ b/commands.go
@@ -517,27 +517,27 @@ func (c *Cmd) PrintLongHelp() {
 func (c *Cmd) printHelp(longDesc bool) {
 	full := append(c.parents, c.name)
 	path := strings.Join(full, " ")
-	fmt.Fprintf(stdErr, "\nUsage: %s", path)
+	fmt.Fprintf(Stderr, "\nUsage: %s", path)
 
 	spec := strings.TrimSpace(c.Spec)
 	if len(spec) > 0 {
-		fmt.Fprintf(stdErr, " %s", spec)
+		fmt.Fprintf(Stderr, " %s", spec)
 	}
 
 	if len(c.commands) > 0 {
-		fmt.Fprint(stdErr, " COMMAND [arg...]")
+		fmt.Fprint(Stderr, " COMMAND [arg...]")
 	}
-	fmt.Fprint(stdErr, "\n\n")
+	fmt.Fprint(Stderr, "\n\n")
 
 	desc := c.desc
 	if longDesc && len(c.LongDesc) > 0 {
 		desc = c.LongDesc
 	}
 	if len(desc) > 0 {
-		fmt.Fprintf(stdErr, "%s\n", desc)
+		fmt.Fprintf(Stderr, "%s\n", desc)
 	}
 
-	w := tabwriter.NewWriter(stdErr, 15, 1, 3, ' ', 0)
+	w := tabwriter.NewWriter(Stderr, 15, 1, 3, ' ', 0)
 
 	if len(c.args) > 0 {
 		fmt.Fprint(w, "\t\nArguments:\t\n")
@@ -676,7 +676,7 @@ func (c *Cmd) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
 	}
 
 	if err := c.fsm.Parse(args[:nargsLen]); err != nil {
-		fmt.Fprintf(stdErr, "Error: %s\n", err.Error())
+		fmt.Fprintf(Stderr, "Error: %s\n", err.Error())
 		c.PrintHelp()
 		c.onError(err)
 		return err
@@ -731,10 +731,10 @@ func (c *Cmd) parse(args []string, entry, inFlow, outFlow *flow.Step) error {
 	switch {
 	case strings.HasPrefix(arg, "-"):
 		err = fmt.Errorf("Error: illegal option %s", arg)
-		fmt.Fprintln(stdErr, err.Error())
+		fmt.Fprintln(Stderr, err.Error())
 	default:
 		err = fmt.Errorf("Error: illegal input %s", arg)
-		fmt.Fprintln(stdErr, err.Error())
+		fmt.Fprintln(Stderr, err.Error())
 	}
 	c.PrintHelp()
 	c.onError(err)


### PR DESCRIPTION
It is useful to test the help output for the non-trivial CLIs and in the
environment where an example outputs are desired.

Before this, testing for help required resorting to `os/exec`.

After this, the consumer test can swap the `cli.Stderr` for testing
purposes while not affecting any other details of the `mow.cli`.

The `stdOut` is not published as it is only used internally for
testing and has no impact on consumers as `mow.cli` never prints to
STDOUT.

NOTE: [alternative implementation] exists but has a larger "blast radius".

[alternative implementation]: https://github.com/jawher/mow.cli/pull/128