### PR TITLE
Add the "Hidden" option for args and options

### DIFF
--- a/args.go
+++ b/args.go
@@ -24,6 +24,8 @@ type BoolArg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a BoolArg) value(into *bool) (flag.Value, *bool) {
@@ -47,6 +49,8 @@ type StringArg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a StringArg) value(into *string) (flag.Value, *string) {
@@ -70,6 +74,8 @@ type IntArg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a IntArg) value(into *int) (flag.Value, *int) {
@@ -93,6 +99,8 @@ type Float64Arg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a Float64Arg) value(into *float64) (flag.Value, *float64) {
@@ -117,6 +125,8 @@ type StringsArg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a StringsArg) value(into *[]string) (flag.Value, *[]string) {
@@ -141,6 +151,8 @@ type IntsArg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a IntsArg) value(into *[]int) (flag.Value, *[]int) {
@@ -165,6 +177,8 @@ type Floats64Arg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a Floats64Arg) value(into *[]float64) (flag.Value, *[]float64) {
@@ -189,6 +203,8 @@ type VarArg struct {
 	HideValue bool
 	// Set to true if this arg was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this arg in the help messages
+	Hidden bool
 }
 
 func (a VarArg) value() flag.Value {

--- a/commands.go
+++ b/commands.go
@@ -173,9 +173,9 @@ func (c *Cmd) BoolPtr(into *bool, p BoolParam) {
 
 	switch x := p.(type) {
 	case BoolOpt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case BoolArg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -192,9 +192,9 @@ func (c *Cmd) String(p StringParam) *string {
 
 	switch x := p.(type) {
 	case StringOpt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case StringArg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -232,9 +232,9 @@ func (c *Cmd) Int(p IntParam) *int {
 
 	switch x := p.(type) {
 	case IntOpt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case IntArg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -293,9 +293,9 @@ func (c *Cmd) Float64Ptr(into *float64, p Float64Param) {
 
 	switch x := p.(type) {
 	case Float64Opt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case Float64Arg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -312,9 +312,9 @@ func (c *Cmd) Strings(p StringsParam) *[]string {
 
 	switch x := p.(type) {
 	case StringsOpt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case StringsArg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -352,9 +352,9 @@ func (c *Cmd) Ints(p IntsParam) *[]int {
 
 	switch x := p.(type) {
 	case IntsOpt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case IntsArg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -392,9 +392,9 @@ func (c *Cmd) Floats64(p Floats64Param) *[]float64 {
 
 	switch x := p.(type) {
 	case Floats64Opt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case Floats64Arg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: value, ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -431,9 +431,9 @@ Instead, the VarOpt or VarOptArg structs hold the said value.
 func (c *Cmd) Var(p VarParam) {
 	switch x := p.(type) {
 	case VarOpt:
-		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: p.value(), ValueSetByUser: x.SetByUser})
+		c.mkOpt(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: p.value(), ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	case VarArg:
-		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: p.value(), ValueSetByUser: x.SetByUser})
+		c.mkArg(container.Container{Name: x.Name, Desc: x.Desc, EnvVar: x.EnvVar, HideValue: x.HideValue, Value: p.value(), ValueSetByUser: x.SetByUser, Hidden: x.Hidden})
 	default:
 		panic(fmt.Sprintf("Unhandled param %v", p))
 	}
@@ -555,6 +555,9 @@ func (c *Cmd) printHelp(longDesc bool) {
 		fmt.Fprint(w, "\t\nOptions:\t\n")
 
 		for _, opt := range c.options {
+			if opt.Hidden {
+				continue
+			}
 			var (
 				optNames = formatOptNamesForHelp(opt)
 				env      = formatEnvVarsForHelp(opt.EnvVar)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -15,4 +15,5 @@ type Container struct {
 	ValueSetByUser  *bool
 	Value           flag.Value
 	DefaultValue    string
+	Hidden          bool
 }

--- a/options.go
+++ b/options.go
@@ -24,6 +24,8 @@ type BoolOpt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o BoolOpt) value(into *bool) (flag.Value, *bool) {
@@ -48,6 +50,8 @@ type StringOpt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o StringOpt) value(into *string) (flag.Value, *string) {
@@ -72,6 +76,8 @@ type IntOpt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o IntOpt) value(into *int) (flag.Value, *int) {
@@ -96,6 +102,8 @@ type Float64Opt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o Float64Opt) value(into *float64) (flag.Value, *float64) {
@@ -121,6 +129,8 @@ type StringsOpt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o StringsOpt) value(into *[]string) (flag.Value, *[]string) {
@@ -146,6 +156,8 @@ type IntsOpt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o IntsOpt) value(into *[]int) (flag.Value, *[]int) {
@@ -172,6 +184,8 @@ type Floats64Opt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o Floats64Opt) value(into *[]float64) (flag.Value, *[]float64) {
@@ -197,6 +211,8 @@ type VarOpt struct {
 	HideValue bool
 	// Set to true if this option was set by the user (as opposed to being set from env or not set at all)
 	SetByUser *bool
+	// Hide this option in the help messages
+	Hidden bool
 }
 
 func (o VarOpt) value() flag.Value {


### PR DESCRIPTION
To be able to hide args or options from the "help" output